### PR TITLE
feat: add canonical link to improve SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>i18nWeave - Manage Your Translations Efficiently</title>
+    <link rel="canonical" href="https://i18nweave.com/" />
     <link rel="stylesheet" href="assets/styles.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap"


### PR DESCRIPTION
Include canonical link in index.html to ensure proper
indexing by search engines and prevent duplicate content issues.