### PR TITLE
fix(nav): correct menu transition for sm breakpoint

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -43,7 +43,9 @@ const IndexPage: React.FC<PageProps> = () => {
         <nav
           ref={menuRef}
           className={`mt-16 lg:flex lg:items-center lg:static lg:p-0 absolute left-0 w-full bg-primary lg:bg-transparent lg:flex-row lg:space-x-4 transition-transform transform lg:mt-0 ${
-            isMenuOpen ? 'translate-y-0 top-0' : '-translate-y-1 -top-48'
+            isMenuOpen
+              ? 'translate-y-0 top-0'
+              : 'sm:-translate-y-1 lg:translate-y-0 -top-48'
           }`}
         >
           <ul className="flex flex-col lg:flex-row lg:space-x-4 space-y-4 lg:space-y-0 p-4 lg:ml-8 lg:p-0">


### PR DESCRIPTION
Update menu transition classes to fix alignment issues 
on small screens by adjusting translate-y values for 
different breakpoints.