### PR TITLE
chore: configure eslint with TypeScript and Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,36 +1,21 @@
 {
-  "overrides": [
-    {
-      "files": [
-        "**/*.{css,scss,less}",
-        "**/*.{json,json5}",
-        "**/*.{graphql}",
-        "**/*.{md,mdx}",
-        "**/*.{html}",
-        "**/*.{yaml,yml}",
-        "**/*.{ts,tsx}"
-      ],
-      "options": {
-        "singleQuote": true,
-        "bracketSpacing": true,
-        "bracketSameLine": true,
-        "trailingComma": "es5",
-        "arrowParens": "avoid",
-        "endOfLine": "crlf",
-        "plugins": ["@trivago/prettier-plugin-sort-imports"],
-        "importOrderParserPlugins": ["decorators", "typescript"],
-        "importOrder": [
-          "^@/(.*)$",
-          "<THIRD_PARTY_MODULES>",
-          "^@i18n-weave/ui/(.*)$",
-          "^@i18n-weave/feat/(.*)$",
-          "^@i18n-weave/util/(.*)$",
-          "^[./]"
-        ],
-        "importOrderSeparation": true,
-        "importOrderSortSpecifiers": true,
-        "importOrderGroupNamespaceSpecifiers": true
-      }
-    }
-  ]
+  "singleQuote": true,
+  "bracketSpacing": true,
+  "bracketSameLine": true,
+  "trailingComma": "es5",
+  "arrowParens": "avoid",
+  "endOfLine": "crlf",
+  "plugins": ["@trivago/prettier-plugin-sort-imports"],
+  "importOrder": [
+    "^@i18n-weave/ui/(.*)$",
+    "^@i18n-weave/feat/(.*)$",
+    "^@i18n-weave/util/(.*)$",
+    "^[./]",
+
+    "^@/(.*)$",
+    "<THIRD_PARTY_MODULES>"
+  ],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true,
+  "importOrderGroupNamespaceSpecifiers": true
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,75 @@
+// eslint.config.js
+const { ESLint } = require('eslint');
+const typescriptEslintPlugin = require('@typescript-eslint/eslint-plugin');
+const importPlugin = require('eslint-plugin-import'); // Ensure this is installed
+
+module.exports = {
+  files: ['**/*.ts', '**/*.tsx'],
+
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020, // Lowered to align with ESLint requirements if it needs it
+      sourceType: 'module'
+    }
+  },
+
+  plugins: {
+    '@typescript-eslint': typescriptEslintPlugin,
+    'import': importPlugin
+  },
+
+  rules: {
+    '@typescript-eslint/naming-convention': [
+      'warn',
+      {
+        selector: 'import',
+        format: ['camelCase', 'PascalCase']
+      }
+    ],
+    // '@typescript-eslint/semi': 'warn',
+    curly: 'warn',
+    eqeqeq: 'warn',
+    'no-throw-literal': 'warn',
+    // semi: 'off',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: false,
+        optionalDependencies: false,
+        peerDependencies: false
+      }
+    ],
+    'import/no-cycle': ['error', { maxDepth: 1 }],
+    'import/order': [
+      'error',
+      {
+        groups: [
+          ['builtin', 'external'],
+          'internal',
+          ['parent', 'sibling', 'index']
+        ],
+        'newlines-between': 'always',
+        alphabetize: { order: 'asc', caseInsensitive: true },
+        distinctGroup: true,
+        warnOnUnassignedImports: false
+      }
+    ],
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: ['../*', './*'] // Restrict relative imports
+      }
+    ]
+  },
+
+  ignores: ['public', '**/*.d.ts', '**/index.ts'],
+
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: ['.ts', '.tsx']
+      }
+    }
+  }
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,59 @@
-// import globals from "globals";
-// import pluginJs from "@eslint/js";
-// import tseslint from "typescript-eslint";
-// import pluginReact from "eslint-plugin-react";
-
+import globals from "globals";
+import pluginJs from "@eslint/js";
+import tseslint from "@typescript-eslint/eslint-plugin";
+import pluginReact from "eslint-plugin-react";
+import tsParser from "@typescript-eslint/parser";
+import prettier from "eslint-config-prettier";
+import importPlugin from "eslint-plugin-import";
 
 export default [
-  // { files: ["src/**/*.{js,mjs,cjs,ts,jsx,tsx}"], ignores: ["src/**/gatsby-types.d.ts"] },
-  // { languageOptions: { globals: globals.browser } },
-  // pluginJs.configs.recommended,
-  // ...tseslint.configs.recommended,
-  // pluginReact.configs.flat.recommended,
+  {
+    files: ["src/**/*.{js,mjs,cjs,ts,jsx,tsx}"],
+    ignores: ["src/**/gatsby-types.d.ts"],
+  },
+  {
+    languageOptions: {
+      globals: globals.browser,
+      parser: tsParser,
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      react: pluginReact,
+      "@typescript-eslint": tseslint,
+      import: importPlugin,
+    },
+    rules: {
+      ...pluginJs.configs.recommended.rules,
+      ...tseslint.configs.recommended.rules,
+      ...pluginReact.configs.recommended.rules,
+      ...prettier.rules,
+      "react/prop-types": "off",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+      "import/order": ["error", { "groups": [["builtin", "external", "internal"]] }],
+    },
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
+  },
+  {
+    files: ["src/**/*.jsx"],
+    rules: {
+      "no-unused-vars": "warn",
+    },
+  },
+  {
+    files: ["src/**/*.tsx"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-explicit-any": "warn", // Add a more strict rule for .tsx files
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "autoprefixer": "^10.4.20",
     "cookie-though": "^1.5.0",
+    "eslint-config-prettier": "^9.1.0",
     "ga-gtag": "^1.2.0",
     "gatsby": "^5.13.7",
     "gatsby-plugin-canonical-urls": "^5.13.1",
@@ -55,13 +56,14 @@
     "@types/node": "^20.16.5",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^8.4.0",
+    "@typescript-eslint/parser": "^8.4.0",
     "eslint": "^9.9.1",
     "eslint-plugin-import": "^2.30.0",
     "eslint-plugin-no-relative-import-paths": "^1.5.5",
     "eslint-plugin-react": "^7.35.2",
     "globals": "^15.9.0",
-    "typescript": "^5.5.4",
-    "typescript-eslint": "^8.4.0"
+    "typescript": "^5.5.4"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -14,17 +14,25 @@
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src"
+    "lint": "eslint --config ./eslint.config.js src/**/*.{js,ts,tsx}",
+    "pretty": "prettier --write \"./src/**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@eslint/js": "^9.10.0",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-brands-svg-icons": "^6.6.0",
     "@fortawesome/free-regular-svg-icons": "^6.6.0",
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "@typescript-eslint/eslint-plugin": "^8.4.0",
+    "@typescript-eslint/parser": "^8.4.0",
     "autoprefixer": "^10.4.20",
     "cookie-though": "^1.5.0",
+    "eslint": "^9.10.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.30.0",
+    "eslint-plugin-react": "^7.35.2",
     "ga-gtag": "^1.2.0",
     "gatsby": "^5.13.7",
     "gatsby-plugin-canonical-urls": "^5.13.1",
@@ -39,6 +47,7 @@
     "gatsby-plugin-sitemap": "^6.13.1",
     "gatsby-source-filesystem": "^5.13.1",
     "gatsby-transformer-sharp": "^5.13.1",
+    "globals": "^15.9.0",
     "i18next": "^23.14.0",
     "postcss": "^8.4.45",
     "react": "^18.3.1",
@@ -50,20 +59,12 @@
     "tsconfig-paths-webpack-plugin": "^4.1.0"
   },
   "devDependencies": {
-    "@eslint/compat": "^1.1.1",
-    "@eslint/js": "^9.9.1",
-    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
-    "@types/node": "^20.16.5",
-    "@types/react": "^18.3.5",
-    "@types/react-dom": "^18.3.0",
-    "@typescript-eslint/eslint-plugin": "^8.4.0",
-    "@typescript-eslint/parser": "^8.4.0",
-    "eslint": "^9.9.1",
-    "eslint-plugin-import": "^2.30.0",
+    "@types/node": "^20.11.19",
+    "@types/react": "^18.2.55",
+    "@types/react-dom": "^18.2.19",
     "eslint-plugin-no-relative-import-paths": "^1.5.5",
-    "eslint-plugin-react": "^7.35.2",
-    "globals": "^15.9.0",
-    "typescript": "^5.5.4"
+    "tsconfig-paths-webpack-plugin": "^4.1.0",
+    "typescript": "^5.3.3"
   },
   "pnpm": {
     "overrides": {
@@ -72,3 +73,4 @@
     }
   }
 }
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     dependencies:
+      '@eslint/js':
+        specifier: ^9.10.0
+        version: 9.10.0
       '@fortawesome/fontawesome-svg-core':
         specifier: ^6.6.0
         version: 6.6.0
@@ -27,15 +30,33 @@ importers:
       '@fortawesome/react-fontawesome':
         specifier: ^0.2.2
         version: 0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1)
+      '@trivago/prettier-plugin-sort-imports':
+        specifier: ^4.3.0
+        version: 4.3.0(prettier@2.8.8)
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.4.0
+        version: 8.4.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/parser':
+        specifier: ^8.4.0
+        version: 8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.45)
       cookie-though:
         specifier: ^1.5.0
         version: 1.5.0
+      eslint:
+        specifier: ^9.10.0
+        version: 9.10.0(jiti@1.21.6)
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@9.10.0(jiti@1.21.6))
+      eslint-plugin-import:
+        specifier: ^2.30.0
+        version: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.10.0(jiti@1.21.6))
+      eslint-plugin-react:
+        specifier: ^7.35.2
+        version: 7.35.2(eslint@9.10.0(jiti@1.21.6))
       ga-gtag:
         specifier: ^1.2.0
         version: 1.2.0
@@ -78,6 +99,9 @@ importers:
       gatsby-transformer-sharp:
         specifier: ^5.13.1
         version: 5.13.1(gatsby-plugin-sharp@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+      globals:
+        specifier: ^15.9.0
+        version: 15.9.0
       i18next:
         specifier: ^23.14.0
         version: 23.14.0
@@ -106,47 +130,20 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
     devDependencies:
-      '@eslint/compat':
-        specifier: ^1.1.1
-        version: 1.1.1
-      '@eslint/js':
-        specifier: ^9.9.1
-        version: 9.10.0
-      '@trivago/prettier-plugin-sort-imports':
-        specifier: ^4.3.0
-        version: 4.3.0(prettier@2.8.8)
       '@types/node':
-        specifier: ^20.16.5
+        specifier: ^20.11.19
         version: 20.16.5
       '@types/react':
-        specifier: ^18.3.5
+        specifier: ^18.2.55
         version: 18.3.5
       '@types/react-dom':
-        specifier: ^18.3.0
+        specifier: ^18.2.19
         version: 18.3.0
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.4.0
-        version: 8.4.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)
-      '@typescript-eslint/parser':
-        specifier: ^8.4.0
-        version: 8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)
-      eslint:
-        specifier: ^9.9.1
-        version: 9.10.0(jiti@1.21.6)
-      eslint-plugin-import:
-        specifier: ^2.30.0
-        version: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.10.0(jiti@1.21.6))
       eslint-plugin-no-relative-import-paths:
         specifier: ^1.5.5
         version: 1.5.5
-      eslint-plugin-react:
-        specifier: ^7.35.2
-        version: 7.35.2(eslint@9.10.0(jiti@1.21.6))
-      globals:
-        specifier: ^15.9.0
-        version: 15.9.0
       typescript:
-        specifier: ^5.5.4
+        specifier: ^5.3.3
         version: 5.5.4
 
 packages:
@@ -895,10 +892,6 @@ packages:
   '@eslint-community/regexpp@4.11.0':
     resolution: {integrity: sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
-  '@eslint/compat@1.1.1':
-    resolution: {integrity: sha512-lpHyRyplhGPL5mGEh6M9O5nnKk0Gz4bFI+Zu6tKlPpDUN7XshWvH9C/px4UVm87IAANE0W81CEsNGbS1KlzXpA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/config-array@0.18.0':
     resolution: {integrity: sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==}
@@ -6291,7 +6284,7 @@ snapshots:
 
   '@babel/generator@7.17.7':
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.25.6
       jsesc: 2.5.2
       source-map: 0.5.7
 
@@ -7213,8 +7206,6 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.11.0': {}
-
-  '@eslint/compat@1.1.1': {}
 
   '@eslint/config-array@0.18.0':
     dependencies:
@@ -8904,7 +8895,7 @@ snapshots:
   camel-case@4.1.2:
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   camelcase-css@2.0.1: {}
 
@@ -8924,7 +8915,7 @@ snapshots:
   capital-case@1.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
       upper-case-first: 2.0.2
 
   chalk@2.4.2:
@@ -9117,7 +9108,7 @@ snapshots:
   constant-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
       upper-case: 2.0.2
 
   content-disposition@0.5.4:
@@ -9491,7 +9482,7 @@ snapshots:
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   dot-prop@5.3.0:
     dependencies:
@@ -11095,7 +11086,7 @@ snapshots:
   header-case@2.0.4:
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   hosted-git-info@3.0.8:
     dependencies:
@@ -11818,7 +11809,7 @@ snapshots:
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   node-abi@3.67.0:
     dependencies:
@@ -12017,7 +12008,7 @@ snapshots:
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   parent-module@1.0.1:
     dependencies:
@@ -12049,7 +12040,7 @@ snapshots:
   pascal-case@3.1.2:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   password-prompt@1.1.3:
     dependencies:
@@ -12059,7 +12050,7 @@ snapshots:
   path-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   path-exists@3.0.0: {}
 
@@ -12804,7 +12795,7 @@ snapshots:
   sentence-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
       upper-case-first: 2.0.2
 
   serialize-javascript@5.0.1:
@@ -12918,7 +12909,7 @@ snapshots:
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   socket.io-adapter@2.5.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,49 +35,49 @@ importers:
         version: 1.5.0
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.0(eslint@9.9.1(jiti@1.21.6))
+        version: 9.1.0(eslint@9.10.0(jiti@1.21.6))
       ga-gtag:
         specifier: ^1.2.0
         version: 1.2.0
       gatsby:
         specifier: ^5.13.7
-        version: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+        version: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       gatsby-plugin-canonical-urls:
         specifier: ^5.13.1
-        version: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
+        version: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
       gatsby-plugin-fontawesome-css:
         specifier: ^1.2.0
-        version: 1.2.0(@fortawesome/fontawesome-svg-core@6.6.0)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
+        version: 1.2.0(@fortawesome/fontawesome-svg-core@6.6.0)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
       gatsby-plugin-image:
         specifier: ^3.13.1
-        version: 3.13.1(@babel/core@7.25.2)(gatsby-plugin-sharp@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0))(gatsby-source-filesystem@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.13.1(@babel/core@7.25.2)(gatsby-plugin-sharp@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0))(gatsby-source-filesystem@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-plugin-manifest:
         specifier: ^5.13.1
-        version: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+        version: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
       gatsby-plugin-pnpm-gatsby-5:
         specifier: ^1.2.11
-        version: 1.2.11(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
+        version: 1.2.11(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
       gatsby-plugin-postcss:
         specifier: ^6.13.1
-        version: 6.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(postcss@8.4.45)(typescript@5.5.4)(webpack@5.94.0)
+        version: 6.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(postcss@8.4.45)(typescript@5.5.4)(webpack@5.94.0)
       gatsby-plugin-prettier-eslint:
         specifier: ^1.0.6
-        version: 1.0.6(eslint@9.9.1(jiti@1.21.6))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(prettier@3.3.3)
+        version: 1.0.6(eslint@9.10.0(jiti@1.21.6))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(prettier@2.8.8)
       gatsby-plugin-react-i18next:
         specifier: ^3.0.1
-        version: 3.0.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(i18next@23.14.0)(react-i18next@15.0.1(i18next@23.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 3.0.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(i18next@23.14.0)(react-i18next@15.0.1(i18next@23.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       gatsby-plugin-sharp:
         specifier: ^5.13.1
-        version: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+        version: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
       gatsby-plugin-sitemap:
         specifier: ^6.13.1
-        version: 6.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-source-filesystem:
         specifier: ^5.13.1
-        version: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
+        version: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
       gatsby-transformer-sharp:
         specifier: ^5.13.1
-        version: 5.13.1(gatsby-plugin-sharp@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+        version: 5.13.1(gatsby-plugin-sharp@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
       i18next:
         specifier: ^23.14.0
         version: 23.14.0
@@ -111,10 +111,10 @@ importers:
         version: 1.1.1
       '@eslint/js':
         specifier: ^9.9.1
-        version: 9.9.1
+        version: 9.10.0
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.3.0
-        version: 4.3.0(prettier@3.3.3)
+        version: 4.3.0(prettier@2.8.8)
       '@types/node':
         specifier: ^20.16.5
         version: 20.16.5
@@ -126,31 +126,28 @@ importers:
         version: 18.3.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.4.0
-        version: 8.4.0(@typescript-eslint/parser@8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.4.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)
       '@typescript-eslint/parser':
         specifier: ^8.4.0
-        version: 8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)
       eslint:
         specifier: ^9.9.1
-        version: 9.9.1(jiti@1.21.6)
+        version: 9.10.0(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.30.0
-        version: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6))
+        version: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.10.0(jiti@1.21.6))
       eslint-plugin-no-relative-import-paths:
         specifier: ^1.5.5
         version: 1.5.5
       eslint-plugin-react:
         specifier: ^7.35.2
-        version: 7.35.2(eslint@9.9.1(jiti@1.21.6))
+        version: 7.35.2(eslint@9.10.0(jiti@1.21.6))
       globals:
         specifier: ^15.9.0
         version: 15.9.0
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
-      typescript-eslint:
-        specifier: ^8.4.0
-        version: 8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
 
 packages:
 
@@ -915,12 +912,16 @@ packages:
     resolution: {integrity: sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.9.1':
-    resolution: {integrity: sha512-xIDQRsfg5hNBqHz04H1R3scSVwmI+KUbqjsQKHKQ1DAUSaUjYPReZZmS/5PNiKu1fUvzDd6H7DEDKACSEhu+TQ==}
+  '@eslint/js@9.10.0':
+    resolution: {integrity: sha512-fuXtbiP5GWIn8Fz+LWoOMVf/Jxm+aajZYkhi6CuEm4SxymFM+eUWzbO9qXT+L0iCkL5+KGYMCSGxo686H19S1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.4':
     resolution: {integrity: sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.1.0':
+    resolution: {integrity: sha512-autAXT203ixhqei9xt+qkYOvY8l6LAFIdT2UXc/RPNeUVfqRF1BV94GTJyVPFKT8nFM6MyVJhjLj9E8JWvf5zQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@fortawesome/fontawesome-common-types@6.6.0':
@@ -2759,8 +2760,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.17:
-    resolution: {integrity: sha512-Q6Q+04tjC2KJ8qsSOSgovvhWcv5t+SmpH6/YfAWmhpE5/r+zw6KQy1/yWVFFNyEBvy68twTTXr2d5eLfCq7QIw==}
+  electron-to-chromium@1.5.18:
+    resolution: {integrity: sha512-1OfuVACu+zKlmjsNdcJuVQuVE61sZOLbNM4JAQ1Rvh6EOj0/EUKhMJjRH73InPlXSh8HIJk1cVZ8pyOV/FMdUQ==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -2888,6 +2889,12 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-config-prettier@9.1.0:
+    resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
   eslint-config-react-app@6.0.0:
     resolution: {integrity: sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3013,8 +3020,8 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     hasBin: true
 
-  eslint@9.9.1:
-    resolution: {integrity: sha512-dHvhrbfr4xFQ9/dq+jcVneZMyRYLjggWjk6RVsIiHsP8Rz6yZ8LvZ//iU4TrZF+SXWG+JkNF2OyiZRvzgRDqMg==}
+  eslint@9.10.0:
+    resolution: {integrity: sha512-Y4D0IgtBZfOcOUAIQTSXBKoNGfY0REGqHJG6+Q81vNippW5YlKjHFj4soMxamKK1NXHUWuBZTLdU3Km+L/pcHw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -5020,9 +5027,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.3.3:
-    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
-    engines: {node: '>=14'}
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
     hasBin: true
 
   pretty-bytes@5.6.0:
@@ -5918,15 +5925,6 @@ packages:
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
-
-  typescript-eslint@8.4.0:
-    resolution: {integrity: sha512-67qoc3zQZe3CAkO0ua17+7aCLI0dU+sSQd1eKPGq06QE4rfQjstVXR6woHO5qQvGUa550NfGckT4tzh3b3c8Pw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   typescript@5.5.4:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
@@ -7204,9 +7202,14 @@ snapshots:
 
   '@builder.io/partytown@0.7.6': {}
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@9.9.1(jiti@1.21.6))':
+  '@eslint-community/eslint-utils@4.4.0(eslint@7.32.0)':
     dependencies:
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 7.32.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.4.0(eslint@9.10.0(jiti@1.21.6))':
+    dependencies:
+      eslint: 9.10.0(jiti@1.21.6)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.11.0': {}
@@ -7249,9 +7252,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.9.1': {}
+  '@eslint/js@9.10.0': {}
 
   '@eslint/object-schema@2.1.4': {}
+
+  '@eslint/plugin-kit@0.1.0':
+    dependencies:
+      levn: 0.4.1
 
   '@fortawesome/fontawesome-common-types@6.6.0': {}
 
@@ -7982,7 +7989,7 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.3.3)':
+  '@trivago/prettier-plugin-sort-imports@4.3.0(prettier@2.8.8)':
     dependencies:
       '@babel/generator': 7.17.7
       '@babel/parser': 7.25.6
@@ -7990,7 +7997,7 @@ snapshots:
       '@babel/types': 7.17.0
       javascript-natural-sort: 0.7.1
       lodash: 4.17.21
-      prettier: 3.3.3
+      prettier: 2.8.8
     transitivePeerDependencies:
       - supports-color
 
@@ -8107,15 +8114,15 @@ snapshots:
 
   '@types/yoga-layout@1.9.2': {}
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
       debug: 4.3.7
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 7.32.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
@@ -8126,15 +8133,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.4.0(@typescript-eslint/parser@8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@8.4.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)
       '@typescript-eslint/scope-manager': 8.4.0
-      '@typescript-eslint/type-utils': 8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/type-utils': 8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 8.4.0
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 9.10.0(jiti@1.21.6)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -8144,26 +8151,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)':
+  '@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
       debug: 4.3.7
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 7.32.0
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)':
+  '@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.4.0
       '@typescript-eslint/types': 8.4.0
       '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 8.4.0
       debug: 4.3.7
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 9.10.0(jiti@1.21.6)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -8179,22 +8186,22 @@ snapshots:
       '@typescript-eslint/types': 8.4.0
       '@typescript-eslint/visitor-keys': 8.4.0
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
       debug: 4.3.7
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 7.32.0
       tsutils: 3.21.0(typescript@5.5.4)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)':
+  '@typescript-eslint/type-utils@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)
       debug: 4.3.7
       ts-api-utils: 1.3.0(typescript@5.5.4)
     optionalDependencies:
@@ -8236,28 +8243,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)':
+  '@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@5.5.4)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.9.1(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@7.32.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 7.32.0
       eslint-scope: 5.1.1
       semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)':
+  '@typescript-eslint/utils@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.9.1(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.10.0(jiti@1.21.6))
       '@typescript-eslint/scope-manager': 8.4.0
       '@typescript-eslint/types': 8.4.0
       '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.5.4)
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 9.10.0(jiti@1.21.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -8590,13 +8597,13 @@ snapshots:
 
   b4a@1.6.6: {}
 
-  babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)):
+  babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)):
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/parser': 7.25.6
       '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 9.10.0(jiti@1.21.6)
       eslint-visitor-keys: 1.3.0
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -8649,12 +8656,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-remove-graphql-queries@5.13.1(@babel/core@7.25.2)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
+  babel-plugin-remove-graphql-queries@5.13.1(@babel/core@7.25.2)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/runtime': 7.25.6
       '@babel/types': 7.25.6
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       gatsby-core-utils: 4.13.1
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
@@ -8831,7 +8838,7 @@ snapshots:
   browserslist@4.23.3:
     dependencies:
       caniuse-lite: 1.0.30001658
-      electron-to-chromium: 1.5.17
+      electron-to-chromium: 1.5.18
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.3)
 
@@ -9502,7 +9509,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.17: {}
+  electron-to-chromium@1.5.18: {}
 
   emoji-regex@8.0.0: {}
 
@@ -9714,18 +9721,22 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0)(typescript@5.5.4))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6)))(eslint-plugin-jsx-a11y@6.10.0(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.35.2(eslint@9.9.1(jiti@1.21.6)))(eslint@7.32.0)(typescript@5.5.4):
+  eslint-config-prettier@9.1.0(eslint@9.10.0(jiti@1.21.6)):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
-      '@typescript-eslint/parser': 5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
-      babel-eslint: 10.1.0(eslint@9.9.1(jiti@1.21.6))
+      eslint: 9.10.0(jiti@1.21.6)
+
+  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0)(typescript@5.5.4))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.10.0(jiti@1.21.6)))(eslint-plugin-jsx-a11y@6.10.0(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.35.2(eslint@9.10.0(jiti@1.21.6)))(eslint@7.32.0)(typescript@5.5.4):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
+      babel-eslint: 10.1.0(eslint@9.10.0(jiti@1.21.6))
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
-      eslint-plugin-flowtype: 5.10.0(eslint@9.9.1(jiti@1.21.6))
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6))
-      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.9.1(jiti@1.21.6))
-      eslint-plugin-react: 7.35.2(eslint@9.9.1(jiti@1.21.6))
-      eslint-plugin-react-hooks: 4.6.2(eslint@9.9.1(jiti@1.21.6))
+      eslint-plugin-flowtype: 5.10.0(eslint@9.10.0(jiti@1.21.6))
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.10.0(jiti@1.21.6))
+      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.10.0(jiti@1.21.6))
+      eslint-plugin-react: 7.35.2(eslint@9.10.0(jiti@1.21.6))
+      eslint-plugin-react-hooks: 4.6.2(eslint@9.10.0(jiti@1.21.6))
     optionalDependencies:
       typescript: 5.5.4
 
@@ -9741,25 +9752,25 @@ snapshots:
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@9.9.1(jiti@1.21.6)):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@9.10.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
-      eslint: 9.9.1(jiti@1.21.6)
+      '@typescript-eslint/parser': 8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)
+      eslint: 9.10.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-flowtype@5.10.0(eslint@9.9.1(jiti@1.21.6)):
+  eslint-plugin-flowtype@5.10.0(eslint@9.10.0(jiti@1.21.6)):
     dependencies:
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 9.10.0(jiti@1.21.6)
       lodash: 4.17.21
       string-natural-compare: 3.0.1
 
@@ -9785,13 +9796,13 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.30.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6)):
+  eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.10.0(jiti@1.21.6)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -9800,9 +9811,9 @@ snapshots:
       array.prototype.flatmap: 1.3.2
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 9.10.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@9.9.1(jiti@1.21.6))
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@9.10.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -9813,13 +9824,13 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.0(eslint@9.9.1(jiti@1.21.6)):
+  eslint-plugin-jsx-a11y@6.10.0(eslint@9.10.0(jiti@1.21.6)):
     dependencies:
       aria-query: 5.1.3
       array-includes: 3.1.8
@@ -9830,7 +9841,7 @@ snapshots:
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       es-iterator-helpers: 1.0.19
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 9.10.0(jiti@1.21.6)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -9841,9 +9852,9 @@ snapshots:
 
   eslint-plugin-no-relative-import-paths@1.5.5: {}
 
-  eslint-plugin-react-hooks@4.6.2(eslint@9.9.1(jiti@1.21.6)):
+  eslint-plugin-react-hooks@4.6.2(eslint@9.10.0(jiti@1.21.6)):
     dependencies:
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 9.10.0(jiti@1.21.6)
 
   eslint-plugin-react@7.35.2(eslint@7.32.0):
     dependencies:
@@ -9867,7 +9878,7 @@ snapshots:
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-react@7.35.2(eslint@9.9.1(jiti@1.21.6)):
+  eslint-plugin-react@7.35.2(eslint@9.10.0(jiti@1.21.6)):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
@@ -9875,7 +9886,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.0.19
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 9.10.0(jiti@1.21.6)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -9967,13 +9978,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint@9.9.1(jiti@1.21.6):
+  eslint@9.10.0(jiti@1.21.6):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.9.1(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.10.0(jiti@1.21.6))
       '@eslint-community/regexpp': 4.11.0
       '@eslint/config-array': 0.18.0
       '@eslint/eslintrc': 3.1.0
-      '@eslint/js': 9.9.1
+      '@eslint/js': 9.10.0
+      '@eslint/plugin-kit': 0.1.0
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.3.0
       '@nodelib/fs.walk': 1.2.8
@@ -9996,7 +10008,6 @@ snapshots:
       is-glob: 4.0.3
       is-path-inside: 3.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
       lodash.merge: 4.6.2
       minimatch: 3.1.2
       natural-compare: 1.4.0
@@ -10458,17 +10469,17 @@ snapshots:
       '@parcel/transformer-js': 2.8.3(@parcel/core@2.8.3)
       '@parcel/transformer-json': 2.8.3(@parcel/core@2.8.3)
 
-  gatsby-plugin-canonical-urls@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
+  gatsby-plugin-canonical-urls@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
     dependencies:
       '@babel/runtime': 7.25.6
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
 
-  gatsby-plugin-fontawesome-css@1.2.0(@fortawesome/fontawesome-svg-core@6.6.0)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
+  gatsby-plugin-fontawesome-css@1.2.0(@fortawesome/fontawesome-svg-core@6.6.0)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
     dependencies:
       '@fortawesome/fontawesome-svg-core': 6.6.0
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
 
-  gatsby-plugin-image@3.13.1(@babel/core@7.25.2)(gatsby-plugin-sharp@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0))(gatsby-source-filesystem@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  gatsby-plugin-image@3.13.1(@babel/core@7.25.2)(gatsby-plugin-sharp@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0))(gatsby-source-filesystem@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/core': 7.25.2
@@ -10476,37 +10487,37 @@ snapshots:
       '@babel/runtime': 7.25.6
       '@babel/traverse': 7.25.6
       babel-jsx-utils: 1.1.0
-      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.25.2)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
+      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.25.2)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
       camelcase: 6.3.0
       chokidar: 3.6.0
       common-tags: 1.8.2
       fs-extra: 11.2.0
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       gatsby-core-utils: 4.13.1
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
       objectFitPolyfill: 2.3.5
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      gatsby-plugin-sharp: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
-      gatsby-source-filesystem: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
+      gatsby-plugin-sharp: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+      gatsby-source-filesystem: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
     transitivePeerDependencies:
       - graphql
       - supports-color
 
-  gatsby-plugin-manifest@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0):
+  gatsby-plugin-manifest@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0):
     dependencies:
       '@babel/runtime': 7.25.6
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       gatsby-core-utils: 4.13.1
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
       semver: 7.6.3
       sharp: 0.32.6
     transitivePeerDependencies:
       - graphql
 
-  gatsby-plugin-page-creator@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0):
+  gatsby-plugin-page-creator@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0):
     dependencies:
       '@babel/runtime': 7.25.6
       '@babel/traverse': 7.25.6
@@ -10514,10 +10525,10 @@ snapshots:
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
       fs-extra: 11.2.0
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       gatsby-core-utils: 4.13.1
       gatsby-page-utils: 3.13.1
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
       gatsby-telemetry: 4.13.1
       globby: 11.1.0
       lodash: 4.17.21
@@ -10526,45 +10537,45 @@ snapshots:
       - graphql
       - supports-color
 
-  gatsby-plugin-pnpm-gatsby-5@1.2.11(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
+  gatsby-plugin-pnpm-gatsby-5@1.2.11(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
     dependencies:
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       lodash.get: 4.4.2
       lodash.uniq: 4.5.0
 
-  gatsby-plugin-postcss@6.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(postcss@8.4.45)(typescript@5.5.4)(webpack@5.94.0):
+  gatsby-plugin-postcss@6.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(postcss@8.4.45)(typescript@5.5.4)(webpack@5.94.0):
     dependencies:
       '@babel/runtime': 7.25.6
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       postcss: 8.4.45
       postcss-loader: 7.3.4(postcss@8.4.45)(typescript@5.5.4)(webpack@5.94.0)
     transitivePeerDependencies:
       - typescript
       - webpack
 
-  gatsby-plugin-prettier-eslint@1.0.6(eslint@9.9.1(jiti@1.21.6))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(prettier@3.3.3):
+  gatsby-plugin-prettier-eslint@1.0.6(eslint@9.10.0(jiti@1.21.6))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(prettier@2.8.8):
     dependencies:
       '@babel/runtime': 7.25.6
       chokidar: 3.6.0
-      eslint: 9.9.1(jiti@1.21.6)
+      eslint: 9.10.0(jiti@1.21.6)
       fast-glob: 3.3.2
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       lodash.mergewith: 4.6.2
       picomatch: 2.3.1
-      prettier: 3.3.3
+      prettier: 2.8.8
 
-  gatsby-plugin-react-i18next@3.0.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(i18next@23.14.0)(react-i18next@15.0.1(i18next@23.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  gatsby-plugin-react-i18next@3.0.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(i18next@23.14.0)(react-i18next@15.0.1(i18next@23.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       bluebird: 3.7.2
       browser-lang: 0.2.1
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       i18next: 23.14.0
       outdent: 0.8.0
       path-to-regexp: 6.2.2
       react: 18.3.1
       react-i18next: 15.0.1(i18next@23.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  gatsby-plugin-sharp@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0):
+  gatsby-plugin-sharp@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0):
     dependencies:
       '@babel/runtime': 7.25.6
       async: 3.2.6
@@ -10572,9 +10583,9 @@ snapshots:
       debug: 4.3.7
       filenamify: 4.3.0
       fs-extra: 11.2.0
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       gatsby-core-utils: 4.13.1
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
       lodash: 4.17.21
       probe-image-size: 7.2.3
       semver: 7.6.3
@@ -10583,17 +10594,17 @@ snapshots:
       - graphql
       - supports-color
 
-  gatsby-plugin-sitemap@6.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  gatsby-plugin-sitemap@6.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.25.6
       common-tags: 1.8.2
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       minimatch: 3.1.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       sitemap: 7.1.2
 
-  gatsby-plugin-typescript@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
+  gatsby-plugin-typescript@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.25.2)
@@ -10601,17 +10612,17 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.25.2)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.25.2)
       '@babel/runtime': 7.25.6
-      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.25.2)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.25.2)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-utils@4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0):
+  gatsby-plugin-utils@4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0):
     dependencies:
       '@babel/runtime': 7.25.6
       fastq: 1.17.1
       fs-extra: 11.2.0
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       gatsby-core-utils: 4.13.1
       gatsby-sharp: 1.13.0
       graphql: 16.9.0
@@ -10638,13 +10649,13 @@ snapshots:
     dependencies:
       sharp: 0.32.6
 
-  gatsby-source-filesystem@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
+  gatsby-source-filesystem@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
     dependencies:
       '@babel/runtime': 7.25.6
       chokidar: 3.6.0
       file-type: 16.5.4
       fs-extra: 11.2.0
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
       gatsby-core-utils: 4.13.1
       mime: 3.0.0
       pretty-bytes: 5.6.0
@@ -10668,15 +10679,15 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  gatsby-transformer-sharp@5.13.1(gatsby-plugin-sharp@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0):
+  gatsby-transformer-sharp@5.13.1(gatsby-plugin-sharp@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0))(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0):
     dependencies:
       '@babel/runtime': 7.25.6
       bluebird: 3.7.2
       common-tags: 1.8.2
       fs-extra: 11.2.0
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
-      gatsby-plugin-sharp: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
+      gatsby-plugin-sharp: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
       probe-image-size: 7.2.3
       semver: 7.6.3
       sharp: 0.32.6
@@ -10693,7 +10704,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4):
+  gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4):
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/core': 7.25.2
@@ -10720,8 +10731,8 @@ snapshots:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@0.21.3)(webpack@5.94.0)
       '@sigmacomputing/babel-plugin-lodash': 3.3.5
       '@types/http-proxy': 1.17.15
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
-      '@typescript-eslint/parser': 5.62.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
       '@vercel/webpack-asset-relocator-loader': 1.7.3
       acorn-loose: 8.4.0
       acorn-walk: 8.3.3
@@ -10733,7 +10744,7 @@ snapshots:
       babel-loader: 8.3.0(@babel/core@7.25.2)(webpack@5.94.0)
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.25.2)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
+      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.25.2)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
       babel-preset-gatsby: 3.13.2(@babel/core@7.25.2)(core-js@3.38.1)
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -10759,12 +10770,12 @@ snapshots:
       enhanced-resolve: 5.17.1
       error-stack-parser: 2.1.4
       eslint: 7.32.0
-      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0)(typescript@5.5.4))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6)))(eslint-plugin-jsx-a11y@6.10.0(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.35.2(eslint@9.9.1(jiti@1.21.6)))(eslint@7.32.0)(typescript@5.5.4)
-      eslint-plugin-flowtype: 5.10.0(eslint@9.9.1(jiti@1.21.6))
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0)(typescript@5.5.4))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.10.0(jiti@1.21.6)))(eslint-plugin-jsx-a11y@6.10.0(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.35.2(eslint@9.10.0(jiti@1.21.6)))(eslint@7.32.0)(typescript@5.5.4)
+      eslint-plugin-flowtype: 5.10.0(eslint@9.10.0(jiti@1.21.6))
       eslint-plugin-import: 2.30.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@7.32.0)
-      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.9.1(jiti@1.21.6))
+      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.10.0(jiti@1.21.6))
       eslint-plugin-react: 7.35.2(eslint@7.32.0)
-      eslint-plugin-react-hooks: 4.6.2(eslint@9.9.1(jiti@1.21.6))
+      eslint-plugin-react-hooks: 4.6.2(eslint@9.10.0(jiti@1.21.6))
       eslint-webpack-plugin: 2.7.0(eslint@7.32.0)(webpack@5.94.0)
       event-source-polyfill: 1.0.31
       execa: 5.1.1
@@ -10783,9 +10794,9 @@ snapshots:
       gatsby-link: 5.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-page-utils: 3.13.1
       gatsby-parcel-config: 1.13.1(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
-      gatsby-plugin-typescript: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.9.1(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+      gatsby-plugin-page-creator: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
+      gatsby-plugin-typescript: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@9.10.0(jiti@1.21.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))(graphql@16.9.0)
       gatsby-react-router-scroll: 6.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-script: 2.13.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-telemetry: 4.13.1
@@ -12350,7 +12361,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.3.3: {}
+  prettier@2.8.8: {}
 
   pretty-bytes@5.6.0: {}
 
@@ -13410,17 +13421,6 @@ snapshots:
       is-typedarray: 1.0.0
 
   typedarray@0.0.6: {}
-
-  typescript-eslint@8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.4.0(@typescript-eslint/parser@8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
-      '@typescript-eslint/parser': 8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
-    optionalDependencies:
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
 
   typescript@5.5.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       cookie-though:
         specifier: ^1.5.0
         version: 1.5.0
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@9.9.1(jiti@1.21.6))
       ga-gtag:
         specifier: ^1.2.0
         version: 1.2.0
@@ -121,12 +124,18 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.4.0
+        version: 8.4.0(@typescript-eslint/parser@8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/parser':
+        specifier: ^8.4.0
+        version: 8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
       eslint:
         specifier: ^9.9.1
         version: 9.9.1(jiti@1.21.6)
       eslint-plugin-import:
         specifier: ^2.30.0
-        version: 2.30.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6))
+        version: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4))(eslint@9.9.1(jiti@1.21.6))
       eslint-plugin-no-relative-import-paths:
         specifier: ^1.5.5
         version: 1.5.5

--- a/src/libs/ui/ui-language-selector/src/lib/language-selector.tsx
+++ b/src/libs/ui/ui-language-selector/src/lib/language-selector.tsx
@@ -1,13 +1,13 @@
-import { FlagIcon, FlagIconCode } from 'react-flag-kit';
-import React, { useState, useEffect, useRef } from 'react';
 import { useI18next } from 'gatsby-plugin-react-i18next';
+import React, { useEffect, useRef, useState } from 'react';
+import { FlagIcon, FlagIconCode } from 'react-flag-kit';
 
 export const LanguageSelector: React.FC = () => {
   const { languages, changeLanguage, language } = useI18next();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
 
-  const toggleDropdown = () => setIsOpen((prev) => !prev);
+  const toggleDropdown = () => setIsOpen(prev => !prev);
 
   const handleClickOutside = (event: globalThis.MouseEvent) => {
     if (
@@ -28,12 +28,10 @@ export const LanguageSelector: React.FC = () => {
   return (
     <div
       className="relative px-4 pb-4 z-20 text-left flex flex-col lg:absolute lg:inline-block lg:right-0 lg:px-0"
-      ref={dropdownRef}
-    >
+      ref={dropdownRef}>
       <button
         onClick={toggleDropdown}
-        className=" inline-flex items-center px-4 py-2 lg:mt-4 text-sm font-medium text-white bg-primary border border-gray-300 rounded-md shadow-sm hover:bg-secondary hover:text-primary focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-      >
+        className=" inline-flex items-center px-4 py-2 lg:mt-4 text-sm font-medium text-white bg-primary border border-gray-300 rounded-md shadow-sm hover:bg-secondary hover:text-primary focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500">
         <FlagIcon
           code={
             language === 'en' ? 'US' : (language.toUpperCase() as FlagIconCode)
@@ -46,8 +44,7 @@ export const LanguageSelector: React.FC = () => {
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
+          stroke="currentColor">
           <path
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -59,17 +56,16 @@ export const LanguageSelector: React.FC = () => {
       {isOpen && (
         <div className="outline-white outline-1 outline w-full z-10 bg-primary border border-primary rounded-md shadow-lg lg:right-0 lg:w-48 lg:absolute">
           <div className="py-1">
-            {languages.map((lng) => (
+            {languages.map(lng => (
               <button
                 type="button"
                 key={lng}
-                onClick={(e) => {
+                onClick={e => {
                   e.preventDefault();
                   changeLanguage(lng);
                   setIsOpen(false); // Close dropdown after language change
                 }}
-                className="flex items-center px-4 py-2 w-full text-sm text-white hover:bg-secondary hover:text-primary hover:font-bold"
-              >
+                className="flex items-center px-4 py-2 w-full text-sm text-white hover:bg-secondary hover:text-primary hover:font-bold">
                 <FlagIcon
                   code={
                     lng === 'en' ? 'US' : (lng.toUpperCase() as FlagIconCode)

--- a/src/libs/ui/ui-layout/src/lib/layout.tsx
+++ b/src/libs/ui/ui-layout/src/lib/layout.tsx
@@ -1,12 +1,3 @@
-import { CookiePreference } from 'cookie-though/dist/types/types';
-import { StaticImage } from 'gatsby-plugin-image';
-import { LanguageSelector } from '@i18n-weave/ui/ui-language-selector';
-import { ReactNode } from 'react';
-import React, { useState, useEffect, useRef } from 'react';
-import { useI18next } from 'gatsby-plugin-react-i18next';
-import { useTranslation } from 'react-i18next';
-import { useGoogleAnalytics } from '@i18n-weave/util/util-google-analytics';
-import { useMicrosoftClarity } from '@i18n-weave/util/util-microsoft-clarity';
 import {
   getPreferences,
   hide,
@@ -14,6 +5,17 @@ import {
   onPreferencesChanged,
   show,
 } from 'cookie-though';
+import { CookiePreference } from 'cookie-though/dist/types/types';
+import { StaticImage } from 'gatsby-plugin-image';
+import { useI18next } from 'gatsby-plugin-react-i18next';
+import { ReactNode } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { LanguageSelector } from '@i18n-weave/ui/ui-language-selector';
+
+import { useGoogleAnalytics } from '@i18n-weave/util/util-google-analytics';
+import { useMicrosoftClarity } from '@i18n-weave/util/util-microsoft-clarity';
 
 interface LayoutProps {
   children: ReactNode;
@@ -56,7 +58,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }: LayoutProps) => {
     if (
       (
         userCookiePreferences.cookieOptions.filter(
-          (x) => x.id === 'statistics'
+          x => x.id === 'statistics'
         )[0] as CookiePreference
       ).isEnabled
     ) {
@@ -70,11 +72,11 @@ export const Layout: React.FC<LayoutProps> = ({ children }: LayoutProps) => {
       });
     }
 
-    onPreferencesChanged((userCookiePreferences) => {
+    onPreferencesChanged(userCookiePreferences => {
       if (
         (
           userCookiePreferences.cookieOptions.filter(
-            (x) => x.id === 'statistics'
+            x => x.id === 'statistics'
           )[0] as CookiePreference
         ).isEnabled
       ) {
@@ -166,8 +168,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }: LayoutProps) => {
           type="button"
           aria-label="Toggle Menu"
           className="block lg:hidden relative text-white focus:outline-none z-10"
-          onClick={() => setIsMenuOpen(!isMenuOpen)}
-        >
+          onClick={() => setIsMenuOpen(!isMenuOpen)}>
           <div className={`hamburger ${isMenuOpen ? 'open' : ''}`}>
             <span className="bar"></span>
             <span className="bar"></span>
@@ -179,15 +180,13 @@ export const Layout: React.FC<LayoutProps> = ({ children }: LayoutProps) => {
           ref={menuRef}
           className={`mt-16 lg:flex lg:items-center lg:static lg:p-0 absolute left-0 w-full bg-primary lg:bg-transparent lg:flex-row lg:space-x-4 transition-transform transform lg:mt-0 ${
             isMenuOpen ? 'translate-y-0 top-0 visible' : '-top-48 hidden'
-          }`}
-        >
+          }`}>
           <ul className="flex flex-col lg:flex-row lg:space-x-4 space-y-4 lg:space-y-0 p-4 lg:ml-8 lg:p-0">
             <li>
               <a
                 href="#features"
                 className="text-white hover:text-highlight"
-                onClick={() => setIsMenuOpen(false)}
-              >
+                onClick={() => setIsMenuOpen(false)}>
                 {t('navigation:main.features')}
               </a>
             </li>
@@ -195,8 +194,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }: LayoutProps) => {
               <a
                 href="#getting-started"
                 className="text-white hover:text-highlight"
-                onClick={() => setIsMenuOpen(false)}
-              >
+                onClick={() => setIsMenuOpen(false)}>
                 {t('navigation:main.gettingStarted')}
               </a>
             </li>
@@ -213,15 +211,13 @@ export const Layout: React.FC<LayoutProps> = ({ children }: LayoutProps) => {
           viewBox="0 0 26 26"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          aria-label="Change Cookie Preferences"
-        >
+          aria-label="Change Cookie Preferences">
           <path
             fillRule="evenodd"
             clipRule="evenodd"
             d="M20.5 14C21.4008 14 22.251 13.7834 23.0014 13.3996C23.0005 13.4329 23 13.4664 23 13.5C23 15.0583 24.0184 16.3788 25.426 16.8321C23.7905 22.1414 18.8459 26 13 26C5.8203 26 0 20.1797 0 13C0 5.8203 5.8203 0 13 0C13.954 0 14.884 0.102758 15.7795 0.29781C15.292 0.899245 15 1.66552 15 2.5C15 3.53742 15.4514 4.46941 16.1684 5.11034C15.4364 6.04443 15 7.22125 15 8.5C15 11.5376 17.4624 14 20.5 14ZM11 7C11 7.55228 10.5523 8 10 8C9.44772 8 9 7.55228 9 7C9 6.44772 9.44772 6 10 6C10.5523 6 11 6.44772 11 7ZM12 13C12 14.1046 11.1046 15 10 15C8.89543 15 8 14.1046 8 13C8 11.8954 8.89543 11 10 11C11.1046 11 12 11.8954 12 13ZM17 20C17.5523 20 18 19.5523 18 19C18 18.4477 17.5523 18 17 18C16.4477 18 16 18.4477 16 19C16 19.5523 16.4477 20 17 20ZM10 19.5C10 20.3284 9.32843 21 8.5 21C7.67157 21 7 20.3284 7 19.5C7 18.6716 7.67157 18 8.5 18C9.32843 18 10 18.6716 10 19.5Z"
             className="fill-primary hover:fill-highlight cursor-pointer"
-            onClick={() => show()}
-          ></path>
+            onClick={() => show()}></path>
         </svg>
       </div>
 

--- a/src/libs/util/eslint.config.js
+++ b/src/libs/util/eslint.config.js
@@ -1,0 +1,22 @@
+// eslint.config.js
+
+const baseConfig = require('../../../eslint.config.js'); // Use require instead of import
+
+module.exports = [
+  baseConfig,
+  {
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["@i18n-weave/ui/*", "@i18n-weave/ui/**/*"],
+              message: "Util should not import from Ui directly."
+            }
+          ]
+        }
+      ]
+    }
+  }
+];

--- a/src/libs/util/util-microsoft-clarity/src/lib/microsoft-clarity.ts
+++ b/src/libs/util/util-microsoft-clarity/src/lib/microsoft-clarity.ts
@@ -16,4 +16,3 @@ export function useMicrosoftClarity() {
     consent,
   };
 }
-

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -1,83 +1,80 @@
 {
-  "cookies": {
-    "essential": {
-      "description": "Wir müssen einige technische Cookies speichern, damit die Website richtig funktioniert.",
-      "label": "Wesentliche Cookies"
-    },
-    "functional": {
-      "description": "Wir müssen einige grundlegende Einstellungen speichern, z. B. die Sprache.",
-      "label": "Funktionale Cookies"
-    },
-    "general": {
-      "cookiePolicy": {
-        "label": "Lies die vollständige Cookie-Erklärung"
-      },
-      "customizeLabel": "Anpassen",
-      "essentialLabel": "Immer an",
-      "header": {
-        "description": "Wir wissen, dass Kekse nicht jedermanns Lieblingssnack sind, aber sie helfen mir (dem Entwickler der Website), dir ein möglichst reibungsloses und fehlerfreies Erlebnis zu bieten. Schon ein paar Krümel können den Unterschied ausmachen!",
-        "subTitle": "Ja, sie ist wieder eine von diesen *Bannern*...",
-        "title": "Möchte jemand Kekse?"
-      },
-      "permissionLabels": {
-        "accept": "Akzeptiere",
-        "acceptAll": "Alles akzeptieren",
-        "decline": "Ablehnen"
-      }
-    },
-    "statistics": {
-      "description": "Wir müssen einige technische Cookies speichern, damit die Website richtig funktioniert.",
-      "label": "Statistik"
-    }
-  },
-  "section": {
-    "features": {
-      "easyConfig": {
-        "description": "",
-        "title": "Einfach konfigurieren"
-      },
-      "foss": {
-        "title": "Frei und Open Source"
-      },
-      "introduction": {
-        "description": "Verwalte deine Übersetzungen ganz einfach mit der i18nWeave VSCode-Erweiterung. i18nWeave bietet eine Vielzahl von Funktionen, die dir helfen, deine Übersetzungen zu verwalten und sie mit deiner Codebasis synchron zu halten.",
-        "support": ""
-      },
-      "keyExtraction": {
-        "description": "",
-        "title": "Auto-Schlüssel-Extraktion"
-      },
-      "support": {
-        "angular": {
-          "description": "Unterstützt Angular i18next",
-          "title": "Angular"
+    "cookies": {
+        "essential": {
+            "description": "Wir müssen einige technische Cookies speichern, damit die Website richtig funktioniert.",
+            "label": "Wesentliche Cookies"
         },
-        "custom": {
-          "description": "Unterstützt alles mit i18next",
-          "title": "Custom"
+        "functional": {
+            "description": "Wir müssen einige grundlegende Einstellungen speichern, z. B. die Sprache.",
+            "label": "Funktionale Cookies"
         },
-        "react": {
-          "description": "Unterstützt React i18next",
-          "title": "React"
+        "general": {
+            "cookiePolicy": {
+                "label": "Lies die vollständige Cookie-Erklärung"
+            },
+            "customizeLabel": "Anpassen",
+            "essentialLabel": "Immer an",
+            "header": {
+                "description": "Wir wissen, dass Kekse nicht jedermanns Lieblingssnack sind, aber sie helfen mir (dem Entwickler der Website), dir ein möglichst reibungsloses und fehlerfreies Erlebnis zu bieten. Schon ein paar Krümel können den Unterschied ausmachen!",
+                "subTitle": "Ja, sie ist wieder eine von diesen *Bannern*...",
+                "title": "Möchte jemand Kekse?"
+            },
+            "permissionLabels": {
+                "accept": "Akzeptiere",
+                "acceptAll": "Alles akzeptieren",
+                "decline": "Ablehnen"
+            }
+        },
+        "statistics": {
+            "description": "Wir müssen einige technische Cookies speichern, damit die Website richtig funktioniert.",
+            "label": "Statistik"
         }
-      },
-      "title": "Verwalte deine Übersetzungen nahtlos"
     },
-    "gettingStarted": {
-      "configureProject": {
-        "description": {
-          "partFour": "auf macOS",
-          "partOne": "Öffne die Befehlspalette und führe den Befehl",
-          "partThree": "auf Windows/Linux oder",
-          "partTwo": "befehl. Folge den Anweisungen, um dein Projekt einzurichten. Um die Befehlspalette zu öffnen, drücke"
+    "section": {
+        "features": {
+            "easyConfig": {
+                "title": "Einfach konfigurieren"
+            },
+            "foss": {
+                "title": "Frei und Open Source"
+            },
+            "introduction": {
+                "description": "Verwalte deine Übersetzungen ganz einfach mit der i18nWeave VSCode-Erweiterung. i18nWeave bietet eine Vielzahl von Funktionen, die dir helfen, deine Übersetzungen zu verwalten und sie mit deiner Codebasis synchron zu halten."
+            },
+            "keyExtraction": {
+                "title": "Auto-Schlüssel-Extraktion"
+            },
+            "support": {
+                "angular": {
+                    "description": "Unterstützt Angular i18next",
+                    "title": "Angular"
+                },
+                "custom": {
+                    "description": "Unterstützt alles mit i18next",
+                    "title": "Custom"
+                },
+                "react": {
+                    "description": "Unterstützt React i18next",
+                    "title": "React"
+                }
+            },
+            "title": "Verwalte deine Übersetzungen nahtlos"
         },
-        "title": "Konfiguriere dein Projekt"
-      },
-      "installExtension": {
-        "description": "Suchen Sie im Fenster der Visual Studio Code-Erweiterungen nach der i18nWeave-Erweiterung oder besuchen Sie die",
-        "title": "Installiere die Erweiterung"
-      },
-      "title": "Erste Schritte"
+        "gettingStarted": {
+            "configureProject": {
+                "description": {
+                    "partFour": "auf macOS",
+                    "partOne": "Öffne die Befehlspalette und führe den Befehl",
+                    "partThree": "auf Windows/Linux oder",
+                    "partTwo": "befehl. Folge den Anweisungen, um dein Projekt einzurichten. Um die Befehlspalette zu öffnen, drücke"
+                },
+                "title": "Konfiguriere dein Projekt"
+            },
+            "installExtension": {
+                "description": "Suchen Sie im Fenster der Visual Studio Code-Erweiterungen nach der i18nWeave-Erweiterung oder besuchen Sie die",
+                "title": "Installiere die Erweiterung"
+            },
+            "title": "Erste Schritte"
+        }
     }
-  }
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,83 +1,80 @@
 {
-  "cookies": {
-    "essential": {
-      "description": "We need to save some technical cookies, for the website to function properly.",
-      "label": "Essential Cookies"
-    },
-    "functional": {
-      "description": "We need to save some basic preferences eg. language.",
-      "label": "Functional Cookies"
-    },
-    "general": {
-      "cookiePolicy": {
-        "label": "Read the full cookie declaration"
-      },
-      "customizeLabel": "Customize",
-      "essentialLabel": "Always on",
-      "header": {
-        "description": "We know, cookies aren't everyone's favorite snack, but they help me (the website's developer) give you the smoothest, bug-free experience possible. Just a few crumbs can make all the difference!",
-        "subTitle": "Yep, it's another one of *those* banners...",
-        "title": "Cookies, Anyone?"
-      },
-      "permissionLabels": {
-        "accept": "Accept",
-        "acceptAll": "Accept all",
-        "decline": "Decline"
-      }
-    },
-    "statistics": {
-      "description": "We need to save some technical cookies, for the website to function properly.",
-      "label": "Statistics"
-    }
-  },
-  "section": {
-    "features": {
-      "easyConfig": {
-        "description": "",
-        "title": "Easy Config"
-      },
-      "foss": {
-        "title": "Free and Open Source"
-      },
-      "introduction": {
-        "description": "Manage your translations with ease using the i18nWeave VSCode extension. i18nWeave provides a wide range of features to help you manage your translations and keep your translations in sync with your codebase.",
-        "support": ""
-      },
-      "keyExtraction": {
-        "description": "",
-        "title": "Auto-Key Extraction"
-      },
-      "support": {
-        "angular": {
-          "description": "Supports Angular i18next",
-          "title": "Angular"
+    "cookies": {
+        "essential": {
+            "description": "We need to save some technical cookies, for the website to function properly.",
+            "label": "Essential Cookies"
         },
-        "custom": {
-          "description": "Supports everything with i18next",
-          "title": "Custom"
+        "functional": {
+            "description": "We need to save some basic preferences eg. language.",
+            "label": "Functional Cookies"
         },
-        "react": {
-          "description": "Supports React i18next",
-          "title": "React"
+        "general": {
+            "cookiePolicy": {
+                "label": "Read the full cookie declaration"
+            },
+            "customizeLabel": "Customize",
+            "essentialLabel": "Always on",
+            "header": {
+                "description": "We know, cookies aren't everyone's favorite snack, but they help me (the website's developer) give you the smoothest, bug-free experience possible. Just a few crumbs can make all the difference!",
+                "subTitle": "Yep, it's another one of *those* banners...",
+                "title": "Cookies, Anyone?"
+            },
+            "permissionLabels": {
+                "accept": "Accept",
+                "acceptAll": "Accept all",
+                "decline": "Decline"
+            }
+        },
+        "statistics": {
+            "description": "We need to save some technical cookies, for the website to function properly.",
+            "label": "Statistics"
         }
-      },
-      "title": "Seamlessly Manage Your Translations"
     },
-    "gettingStarted": {
-      "configureProject": {
-        "description": {
-          "partFour": "on macOS",
-          "partOne": "Open the command palette and run the",
-          "partThree": "on Windows/Linux or",
-          "partTwo": "command. Follow the instructions to set up your project. To open the command palette, press"
+    "section": {
+        "features": {
+            "easyConfig": {
+                "title": "Easy Config"
+            },
+            "foss": {
+                "title": "Free and Open Source"
+            },
+            "introduction": {
+                "description": "Manage your translations with ease using the i18nWeave VSCode extension. i18nWeave provides a wide range of features to help you manage your translations and keep your translations in sync with your codebase."
+            },
+            "keyExtraction": {
+                "title": "Auto-Key Extraction"
+            },
+            "support": {
+                "angular": {
+                    "description": "Supports Angular i18next",
+                    "title": "Angular"
+                },
+                "custom": {
+                    "description": "Supports everything with i18next",
+                    "title": "Custom"
+                },
+                "react": {
+                    "description": "Supports React i18next",
+                    "title": "React"
+                }
+            },
+            "title": "Seamlessly Manage Your Translations"
         },
-        "title": "Configure Your Project"
-      },
-      "installExtension": {
-        "description": "Search for the i18nWeave extension in the Visual Studio Code extensions window or visit the",
-        "title": "Install the Extension"
-      },
-      "title": "Getting Started"
+        "gettingStarted": {
+            "configureProject": {
+                "description": {
+                    "partFour": "on macOS",
+                    "partOne": "Open the command palette and run the",
+                    "partThree": "on Windows/Linux or",
+                    "partTwo": "command. Follow the instructions to set up your project. To open the command palette, press"
+                },
+                "title": "Configure Your Project"
+            },
+            "installExtension": {
+                "description": "Search for the i18nWeave extension in the Visual Studio Code extensions window or visit the",
+                "title": "Install the Extension"
+            },
+            "title": "Getting Started"
+        }
     }
-  }
 }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -1,83 +1,80 @@
 {
-  "cookies": {
-    "essential": {
-      "description": "Nous devons enregistrer certains cookies techniques, pour que le site Internet fonctionne correctement.",
-      "label": "Biscuits essentiels"
-    },
-    "functional": {
-      "description": "Nous devons sauvegarder certaines préférences de base, par exemple la langue.",
-      "label": "Cookies fonctionnels"
-    },
-    "general": {
-      "cookiePolicy": {
-        "label": "Lire la déclaration complète sur les cookies"
-      },
-      "customizeLabel": "Personnaliser",
-      "essentialLabel": "Toujours en marche",
-      "header": {
-        "description": "Nous savons que les biscuits ne sont pas la collation préférée de tout le monde, mais ils m'aident (le développeur du site Web) à te donner l'expérience la plus fluide et la plus exempte de bogues possible. Quelques miettes peuvent faire toute la différence !",
-        "subTitle": "Oui, c'est encore une de ces *bannières*...",
-        "title": "Des biscuits, ça te dit ?"
-      },
-      "permissionLabels": {
-        "accept": "Accepter",
-        "acceptAll": "Accepte tout",
-        "decline": "Rejeter"
-      }
-    },
-    "statistics": {
-      "description": "Nous devons enregistrer certains cookies techniques, pour que le site Internet fonctionne correctement.",
-      "label": "Statistiques"
-    }
-  },
-  "section": {
-    "features": {
-      "easyConfig": {
-        "description": "",
-        "title": "Configuration facile"
-      },
-      "foss": {
-        "title": "Source libre et gratuite"
-      },
-      "introduction": {
-        "description": "Gère tes traductions en toute simplicité grâce à l'extension VSCode d'i18nWeave. i18nWeave propose un large éventail de fonctionnalités pour t'aider à gérer tes traductions et à les garder synchronisées avec ta base de code.",
-        "support": ""
-      },
-      "keyExtraction": {
-        "description": "",
-        "title": "Extraction de clé automatique"
-      },
-      "support": {
-        "angular": {
-          "description": "Prend en charge Angular i18next",
-          "title": "Angular"
+    "cookies": {
+        "essential": {
+            "description": "Nous devons enregistrer certains cookies techniques, pour que le site Internet fonctionne correctement.",
+            "label": "Biscuits essentiels"
         },
-        "custom": {
-          "description": "Prend tout en charge avec i18next",
-          "title": "Sur mesure"
+        "functional": {
+            "description": "Nous devons sauvegarder certaines préférences de base, par exemple la langue.",
+            "label": "Cookies fonctionnels"
         },
-        "react": {
-          "description": "Prend en charge React i18next",
-          "title": "React"
+        "general": {
+            "cookiePolicy": {
+                "label": "Lire la déclaration complète sur les cookies"
+            },
+            "customizeLabel": "Personnaliser",
+            "essentialLabel": "Toujours en marche",
+            "header": {
+                "description": "Nous savons que les biscuits ne sont pas la collation préférée de tout le monde, mais ils m'aident (le développeur du site Web) à te donner l'expérience la plus fluide et la plus exempte de bogues possible. Quelques miettes peuvent faire toute la différence !",
+                "subTitle": "Oui, c'est encore une de ces *bannières*...",
+                "title": "Des biscuits, ça te dit ?"
+            },
+            "permissionLabels": {
+                "accept": "Accepter",
+                "acceptAll": "Accepte tout",
+                "decline": "Rejeter"
+            }
+        },
+        "statistics": {
+            "description": "Nous devons enregistrer certains cookies techniques, pour que le site Internet fonctionne correctement.",
+            "label": "Statistiques"
         }
-      },
-      "title": "Gère tes traductions en toute transparence"
     },
-    "gettingStarted": {
-      "configureProject": {
-        "description": {
-          "partFour": "on macOS",
-          "partOne": "Ouvre la palette de commandes et exécute la commande",
-          "partThree": "on Windows/Linux or",
-          "partTwo": "commande. Suis les instructions pour configurer ton projet. Pour ouvrir la palette de commandes, appuie sur"
+    "section": {
+        "features": {
+            "easyConfig": {
+                "title": "Configuration facile"
+            },
+            "foss": {
+                "title": "Source libre et gratuite"
+            },
+            "introduction": {
+                "description": "Gère tes traductions en toute simplicité grâce à l'extension VSCode d'i18nWeave. i18nWeave propose un large éventail de fonctionnalités pour t'aider à gérer tes traductions et à les garder synchronisées avec ta base de code."
+            },
+            "keyExtraction": {
+                "title": "Extraction de clé automatique"
+            },
+            "support": {
+                "angular": {
+                    "description": "Prend en charge Angular i18next",
+                    "title": "Angular"
+                },
+                "custom": {
+                    "description": "Prend tout en charge avec i18next",
+                    "title": "Sur mesure"
+                },
+                "react": {
+                    "description": "Prend en charge React i18next",
+                    "title": "React"
+                }
+            },
+            "title": "Gère tes traductions en toute transparence"
         },
-        "title": "Configure ton projet"
-      },
-      "installExtension": {
-        "description": "Recherche l'extension i18nWeave dans la fenêtre d'extensions de Visual Studio Code ou visite le site de l'entreprise",
-        "title": "Installer l'extension"
-      },
-      "title": "Pour commencer"
+        "gettingStarted": {
+            "configureProject": {
+                "description": {
+                    "partFour": "on macOS",
+                    "partOne": "Ouvre la palette de commandes et exécute la commande",
+                    "partThree": "on Windows/Linux or",
+                    "partTwo": "commande. Suis les instructions pour configurer ton projet. Pour ouvrir la palette de commandes, appuie sur"
+                },
+                "title": "Configure ton projet"
+            },
+            "installExtension": {
+                "description": "Recherche l'extension i18nWeave dans la fenêtre d'extensions de Visual Studio Code ou visite le site de l'entreprise",
+                "title": "Installer l'extension"
+            },
+            "title": "Pour commencer"
+        }
     }
-  }
 }

--- a/src/locales/nl/common.json
+++ b/src/locales/nl/common.json
@@ -1,83 +1,80 @@
 {
-  "cookies": {
-    "essential": {
-      "description": "We moeten een aantal technische cookies opslaan om de website goed te laten functioneren.",
-      "label": "Essentiële koekjes"
-    },
-    "functional": {
-      "description": "We moeten een aantal basisvoorkeuren opslaan, zoals taal.",
-      "label": "Functionele cookies"
-    },
-    "general": {
-      "cookiePolicy": {
-        "label": "Lees de volledige cookieverklaring"
-      },
-      "customizeLabel": "Pas  aan",
-      "essentialLabel": "Altijd aan",
-      "header": {
-        "description": "We weten dat koekjes niet ieders favoriete snack zijn, maar ze helpen mij (de ontwikkelaar van de website) wel om je een zo soepel mogelijke ervaring zonder bugs te geven. Een paar kruimels kunnen al het verschil maken!",
-        "subTitle": "Ja, het is weer zo'n pop-up...",
-        "title": "Koekjes, iemand?"
-      },
-      "permissionLabels": {
-        "accept": "Accepteer",
-        "acceptAll": "Alles accepteren",
-        "decline": "Afwijzen"
-      }
-    },
-    "statistics": {
-      "description": "We moeten een aantal technische cookies opslaan om de website goed te laten functioneren.",
-      "label": "Statistieken"
-    }
-  },
-  "section": {
-    "features": {
-      "easyConfig": {
-        "description": "",
-        "title": "Eenvoudige configuratie"
-      },
-      "foss": {
-        "title": "Gratis en Open Source"
-      },
-      "introduction": {
-        "description": "Beheer je vertalingen eenvoudig met de i18nWeave VSCode-extensie. i18nWeave biedt een groot aantal functies om je te helpen je vertalingen te beheren en je vertalingen synchroon te houden met je codebase.",
-        "support": ""
-      },
-      "keyExtraction": {
-        "description": "",
-        "title": "Automatische sleutelextractie"
-      },
-      "support": {
-        "angular": {
-          "description": "Ondersteunt Angular i18next",
-          "title": "Angular"
+    "cookies": {
+        "essential": {
+            "description": "We moeten een aantal technische cookies opslaan om de website goed te laten functioneren.",
+            "label": "Essentiële koekjes"
         },
-        "custom": {
-          "description": "Ondersteunt alles met i18next",
-          "title": "Custom"
+        "functional": {
+            "description": "We moeten een aantal basisvoorkeuren opslaan, zoals taal.",
+            "label": "Functionele cookies"
         },
-        "react": {
-          "description": "Ondersteunt React i18next",
-          "title": "React"
+        "general": {
+            "cookiePolicy": {
+                "label": "Lees de volledige cookieverklaring"
+            },
+            "customizeLabel": "Pas  aan",
+            "essentialLabel": "Altijd aan",
+            "header": {
+                "description": "We weten dat koekjes niet ieders favoriete snack zijn, maar ze helpen mij (de ontwikkelaar van de website) wel om je een zo soepel mogelijke ervaring zonder bugs te geven. Een paar kruimels kunnen al het verschil maken!",
+                "subTitle": "Ja, het is weer zo'n pop-up...",
+                "title": "Koekjes, iemand?"
+            },
+            "permissionLabels": {
+                "accept": "Accepteer",
+                "acceptAll": "Alles accepteren",
+                "decline": "Afwijzen"
+            }
+        },
+        "statistics": {
+            "description": "We moeten een aantal technische cookies opslaan om de website goed te laten functioneren.",
+            "label": "Statistieken"
         }
-      },
-      "title": "Naadloos je vertalingen beheren"
     },
-    "gettingStarted": {
-      "configureProject": {
-        "description": {
-          "partFour": "op macOS",
-          "partOne": "Open het commandopalet en voer het",
-          "partThree": "op Windows/Linux of",
-          "partTwo": "opdracht. Volg de instructies om je project op te zetten. Om het opdrachtenpalet te openen, druk je op"
+    "section": {
+        "features": {
+            "easyConfig": {
+                "title": "Eenvoudige configuratie"
+            },
+            "foss": {
+                "title": "Gratis en Open Source"
+            },
+            "introduction": {
+                "description": "Beheer je vertalingen eenvoudig met de i18nWeave VSCode-extensie. i18nWeave biedt een groot aantal functies om je te helpen je vertalingen te beheren en je vertalingen synchroon te houden met je codebase."
+            },
+            "keyExtraction": {
+                "title": "Automatische sleutelextractie"
+            },
+            "support": {
+                "angular": {
+                    "description": "Ondersteunt Angular i18next",
+                    "title": "Angular"
+                },
+                "custom": {
+                    "description": "Ondersteunt alles met i18next",
+                    "title": "Custom"
+                },
+                "react": {
+                    "description": "Ondersteunt React i18next",
+                    "title": "React"
+                }
+            },
+            "title": "Naadloos je vertalingen beheren"
         },
-        "title": "Je project configureren"
-      },
-      "installExtension": {
-        "description": "Zoek naar de i18nWeave-extensie in het uitbreidingsvenster van Visual Studio Code of ga naar de",
-        "title": "De extensie installeren"
-      },
-      "title": "Aan de slag"
+        "gettingStarted": {
+            "configureProject": {
+                "description": {
+                    "partFour": "op macOS",
+                    "partOne": "Open het commandopalet en voer het",
+                    "partThree": "op Windows/Linux of",
+                    "partTwo": "opdracht. Volg de instructies om je project op te zetten. Om het opdrachtenpalet te openen, druk je op"
+                },
+                "title": "Je project configureren"
+            },
+            "installExtension": {
+                "description": "Zoek naar de i18nWeave-extensie in het uitbreidingsvenster van Visual Studio Code of ga naar de",
+                "title": "De extensie installeren"
+            },
+            "title": "Aan de slag"
+        }
     }
-  }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
-import { useTranslation } from 'react-i18next';
+import { Layout } from '@i18n-weave/ui/ui-layout';
+
 import * as React from 'react';
-import { graphql, type PageProps } from 'gatsby';
+import { faAngular, faReact } from '@fortawesome/free-brands-svg-icons';
 import {
   faCheckDouble,
   faCode,
@@ -8,8 +9,8 @@ import {
   faObjectGroup,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faAngular, faReact } from '@fortawesome/free-brands-svg-icons';
-import { Layout } from '@i18n-weave/ui/ui-layout';
+import { type PageProps, graphql } from 'gatsby';
+import { useTranslation } from 'react-i18next';
 
 const IndexPage: React.FC<PageProps> = () => {
   const { t } = useTranslation();
@@ -18,8 +19,7 @@ const IndexPage: React.FC<PageProps> = () => {
     <Layout>
       <section
         id="features"
-        className="h-screen flex flex-col items-center bg-variant-1 snap-start scroll-mt-16 pt-8 text-center"
-      >
+        className="h-screen flex flex-col items-center bg-variant-1 snap-start scroll-mt-16 pt-8 text-center">
         <div className="pb-4 px-4 lg:px-12 lg:pb-16 max-w-screen-xl">
           <h1 className="text-white text-4xl mb-8">
             {t('section.features.title')}
@@ -86,8 +86,7 @@ const IndexPage: React.FC<PageProps> = () => {
       </section>
       <section
         id="getting-started"
-        className="h-screen flex flex-col items-center bg-variant-2 snap-start scroll-mt-16 pt-8"
-      >
+        className="h-screen flex flex-col items-center bg-variant-2 snap-start scroll-mt-16 pt-8">
         <h2 className="text-primary text-4xl mb-8 text-center max-w-screen-xl">
           {t('section.gettingStarted.title')}
         </h2>
@@ -101,8 +100,7 @@ const IndexPage: React.FC<PageProps> = () => {
             {t('section.gettingStarted.installExtension.description')}{' '}
             <a
               className="text-primary underline"
-              href="https://marketplace.visualstudio.com/items?itemName=qvotaxon.i18nweave"
-            >
+              href="https://marketplace.visualstudio.com/items?itemName=qvotaxon.i18nweave">
               Visual Studio Code Marketplace.
             </a>
           </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -120,5 +120,5 @@
     "./gatsby-config.ts",
     "./plugins/**/*",
     "static"
-  ]
+, "src/libs/util/.eslintrc.js"  ]
 }


### PR DESCRIPTION
Enable ESLint with TypeScript and Prettier support. Add @typescript-eslint plugins and rules for improved TypeScript linting. Integrate prettier config. Customize specific rules and settings for .jsx and .tsx files. Include dependencies in package.json and update pnpm-lock.yaml to reflect changes.