### PR TITLE
refactor(seo): refine alternate links and improve readability

### DIFF
--- a/src/libs/ui/ui-seo/src/lib/seo.tsx
+++ b/src/libs/ui/ui-seo/src/lib/seo.tsx
@@ -15,7 +15,10 @@ const getCurrentLanguage = (pathname: string): string => {
 };
 
 export const SEO: React.FC<SEOProps> = ({ title, description, keywords }) => {
-  const { pathname, origin } = typeof window !== 'undefined' ? window.location : { pathname: '/', origin: 'https://i18nweave.com' };
+  const { pathname, origin } =
+    typeof window !== 'undefined'
+      ? window.location
+      : { pathname: '/', origin: 'https://i18nweave.com' };
   const language = getCurrentLanguage(pathname);
   const originalPath = pathname.replace(`/${language}`, '') || '/';
   const baseUrl = origin;
@@ -29,14 +32,16 @@ export const SEO: React.FC<SEOProps> = ({ title, description, keywords }) => {
       <meta name="keywords" content={keywords} />
       <link rel="canonical" href={canonicalUrl} />
 
-      {availableLanguages.map((lang) => (
-        <link
-          key={lang}
-          rel="alternate"
-          href={`${baseUrl}${lang === 'en' ? '' : `/${lang}`}${originalPath === '/' ? '' : originalPath}`}
-          hrefLang={lang}
-        />
-      ))}
+      {availableLanguages
+        .filter(x => x !== language)
+        .map(lang => (
+          <link
+            key={lang}
+            rel="alternate"
+            href={`${baseUrl}${lang === 'en' ? '' : `/${lang}`}${originalPath === '/' ? '' : originalPath}`}
+            hrefLang={lang}
+          />
+        ))}
     </>
   );
 };


### PR DESCRIPTION
Refactor the SEO component to exclude the current language from the alternate link tags. This ensures that each page only provides alternate links for other available languages, thus improving SEO and avoiding self-references. Also, improve the readability of the `origin` and `pathname` extraction logic.