### PR TITLE
fix: update SEO components and refactor page contexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "cookie-though": "^1.5.0",
     "ga-gtag": "^1.2.0",
     "gatsby": "^5.13.7",
-    "gatsby-plugin-canonical-urls": "^5.13.1",
     "gatsby-plugin-fontawesome-css": "^1.2.0",
     "gatsby-plugin-image": "^3.13.1",
     "gatsby-plugin-manifest": "^5.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,6 @@ importers:
       gatsby:
         specifier: ^5.13.7
         version: 5.13.7(babel-eslint@10.1.0(eslint@7.32.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
-      gatsby-plugin-canonical-urls:
-        specifier: ^5.13.1
-        version: 5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@7.32.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
       gatsby-plugin-fontawesome-css:
         specifier: ^1.2.0
         version: 1.2.0(@fortawesome/fontawesome-svg-core@6.6.0)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@7.32.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4))
@@ -3188,12 +3185,6 @@ packages:
     engines: {parcel: 2.x}
     peerDependencies:
       '@parcel/core': ^2.0.0
-
-  gatsby-plugin-canonical-urls@5.13.1:
-    resolution: {integrity: sha512-rnVEfz7gIPgYk/go/fk5tM5Iv/7Qe6GonquhWMkDNPvRJPJ0qkv37Hv1l/BrC/2AHz9RNQsSZJRonVPPSHlhgA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      gatsby: ^5.0.0-next
 
   gatsby-plugin-fontawesome-css@1.2.0:
     resolution: {integrity: sha512-Me7zFKPDmFQAWZmC2MQN7vWSHGFneu6FeIylkVinSMh89C0wPeoF165rpfuEdpgG0HScNg0fSh3xCIxYr5gPOQ==}
@@ -8598,7 +8589,7 @@ snapshots:
   camel-case@4.1.2:
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   camelcase-css@2.0.1: {}
 
@@ -8618,7 +8609,7 @@ snapshots:
   capital-case@1.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
       upper-case-first: 2.0.2
 
   chalk@2.4.2:
@@ -8811,7 +8802,7 @@ snapshots:
   constant-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
       upper-case: 2.0.2
 
   content-disposition@0.5.4:
@@ -9185,7 +9176,7 @@ snapshots:
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   dot-prop@5.3.0:
     dependencies:
@@ -10034,11 +10025,6 @@ snapshots:
       '@parcel/transformer-js': 2.8.3(@parcel/core@2.8.3)
       '@parcel/transformer-json': 2.8.3(@parcel/core@2.8.3)
 
-  gatsby-plugin-canonical-urls@5.13.1(gatsby@5.13.7(babel-eslint@10.1.0(eslint@7.32.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
-    dependencies:
-      '@babel/runtime': 7.25.6
-      gatsby: 5.13.7(babel-eslint@10.1.0(eslint@7.32.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)
-
   gatsby-plugin-fontawesome-css@1.2.0(@fortawesome/fontawesome-svg-core@6.6.0)(gatsby@5.13.7(babel-eslint@10.1.0(eslint@7.32.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.5.4)):
     dependencies:
       '@fortawesome/fontawesome-svg-core': 6.6.0
@@ -10647,7 +10633,7 @@ snapshots:
   header-case@2.0.4:
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   hosted-git-info@3.0.8:
     dependencies:
@@ -11366,7 +11352,7 @@ snapshots:
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   node-abi@3.67.0:
     dependencies:
@@ -11565,7 +11551,7 @@ snapshots:
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   parent-module@1.0.1:
     dependencies:
@@ -11597,7 +11583,7 @@ snapshots:
   pascal-case@3.1.2:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   password-prompt@1.1.3:
     dependencies:
@@ -11607,7 +11593,7 @@ snapshots:
   path-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   path-exists@3.0.0: {}
 
@@ -12352,7 +12338,7 @@ snapshots:
   sentence-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
       upper-case-first: 2.0.2
 
   serialize-javascript@5.0.1:
@@ -12466,7 +12452,7 @@ snapshots:
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.7.0
 
   socket.io-adapter@2.5.5:
     dependencies:

--- a/src/libs/ui/ui-seo/src/lib/seo.tsx
+++ b/src/libs/ui/ui-seo/src/lib/seo.tsx
@@ -1,48 +1,61 @@
 import React from 'react';
 
+export type PageContext = {
+  language: string;
+  i18n: {
+    language: string;
+    languages: string[];
+    defaultLanguage: string;
+    generateDefaultLanguagePage: boolean;
+    routed: boolean;
+    originalPath: string;
+    path: string;
+  };
+};
+
 type SEOProps = {
   title: string;
   description: string;
   keywords: string;
+  pathname: string;
+  pageContext: PageContext;
 };
 
-const availableLanguages = ['en', 'nl', 'de', 'fr', 'es'];
-
-const getCurrentLanguage = (pathname: string): string => {
-  const pathSegments = pathname.split('/').filter(Boolean);
-  const potentialLang = pathSegments[0];
-  return availableLanguages.includes(potentialLang) ? potentialLang : 'en';
-};
-
-export const SEO: React.FC<SEOProps> = ({ title, description, keywords }) => {
-  const { pathname, origin } =
+export const SEO: React.FC<SEOProps> = ({
+  title,
+  description,
+  keywords,
+  pathname,
+  pageContext,
+}) => {
+  const currentLanguage = pageContext.language;
+  const origin =
     typeof window !== 'undefined'
-      ? window.location
-      : { pathname: '/', origin: 'https://i18nweave.com' };
-  const language = getCurrentLanguage(pathname);
-  const originalPath = pathname.replace(`/${language}`, '') || '/';
-  const baseUrl = origin;
-
-  const canonicalUrl = `${baseUrl}${language === 'en' ? '' : `/${language}`}${originalPath === '/' ? '' : originalPath}`;
+      ? window.location.origin
+      : { origin: 'https://i18nweave.com' };
+  const originalPath = pathname.replace(`/${currentLanguage}`, '') || '/';
+  const canonicalUrl = `${origin}${currentLanguage === 'en' ? '' : `/${currentLanguage}`}${originalPath === '/' ? '' : originalPath}`;
 
   return (
-    <>
-      <title>i18nWeave - {title}</title>
-      <meta name="description" content={description} />
-      <meta name="keywords" content={keywords} />
-      <link rel="canonical" href={canonicalUrl} />
+    <html lang={currentLanguage}>
+      <head>
+        <title>i18nWeave - {title}</title>
+        <meta name="description" content={description} />
+        <meta name="keywords" content={keywords} />
+        <link rel="canonical" href={canonicalUrl} />
 
-      {availableLanguages
-        .filter(x => x !== language)
-        .map(lang => (
-          <link
-            key={lang}
-            rel="alternate"
-            href={`${baseUrl}${lang === 'en' ? '' : `/${lang}`}${originalPath === '/' ? '' : originalPath}`}
-            hrefLang={lang}
-          />
-        ))}
-    </>
+        {pageContext.i18n.languages
+          .filter(x => x !== currentLanguage)
+          .map(lang => (
+            <link
+              key={lang}
+              rel="alternate"
+              href={`${origin}${lang === 'en' ? '' : `/${lang}`}${originalPath === '/' ? '' : originalPath}`}
+              hrefLang={lang}
+            />
+          ))}
+      </head>
+    </html>
   );
 };
 

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
+
+import { Layout } from '@i18n-weave/ui/ui-layout';
+import { type PageContext, SEO } from '@i18n-weave/ui/ui-seo';
+
 import { PageProps, graphql } from 'gatsby';
 import { useTranslation } from 'react-i18next';
-
-import {Layout} from '@i18n-weave/ui/ui-layout';
-import { SEO } from '@i18n-weave/ui/ui-seo';
 
 const NotFoundPage: React.FC<PageProps> = () => {
   const { t } = useTranslation();
@@ -12,8 +13,8 @@ const NotFoundPage: React.FC<PageProps> = () => {
     <Layout>
       <section className="h-screen flex flex-col items-center bg-variant-1 snap-start scroll-mt-16 pt-8 text-center [@media_(max-height:666px)]:h-fit">
         <h1 className="text-4xl">{t('404.pageNotFound.title')}</h1>
-        <p className='text-2xl pt-6'>{t('404.pageNotFound.errorMessage')}</p>
-        <p className='text-6xl pt-6'>¯\_(ツ)_/¯</p>
+        <p className="text-2xl pt-6">{t('404.pageNotFound.errorMessage')}</p>
+        <p className="text-6xl pt-6">¯\_(ツ)_/¯</p>
       </section>
     </Layout>
   );
@@ -35,10 +36,16 @@ export const query = graphql`
 
 export default NotFoundPage;
 
-export const Head = (props: PageProps) => (
-  <SEO
-    title="Developer&apos;s i18n Companion"
-    description="i18nWeave helps developers efficiently handle i18next translations in their projects. Increase productivity and ensure consistency across multiple languages."
-    keywords="i18next, i18n, react, next.js, angular, i18n-next, deepl, internationalization, VSCode extension, translations, developer tools"
-  />
-);
+export const Head = (props: PageProps<PageProps, PageContext>) => {
+  const { t } = useTranslation();
+
+  return (
+    <SEO
+      title="Developer's i18n Companion"
+      description="i18nWeave helps developers efficiently handle i18next translations in their projects. Increase productivity and ensure consistency across multiple languages."
+      keywords="i18next, i18n, react, next.js, angular, i18n-next, deepl, internationalization, VSCode extension, translations, developer tools"
+      pageContext={props.pageContext}
+      pathname={props.location.pathname}
+    />
+  );
+};

--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import { Layout } from '@i18n-weave/ui/ui-layout';
-import { SEO } from '@i18n-weave/ui/ui-seo';
 import { SecureLink } from '@i18n-weave/ui/ui-secure-link';
+import { type PageContext, SEO } from '@i18n-weave/ui/ui-seo';
 
 import { type PageProps, graphql } from 'gatsby';
 import { useTranslation } from 'react-i18next';
@@ -55,13 +55,17 @@ const FeaturesPage: React.FC<PageProps> = () => {
 
 export default FeaturesPage;
 
-export const Head = (props: PageProps) => (
-  <SEO
-    title="Developer&apos;s i18n Companion"
-    description="i18nWeave helps developers efficiently handle i18next translations in their projects. Increase productivity and ensure consistency across multiple languages."
-    keywords="i18next, i18n, react, next.js, angular, i18n-next, deepl, internationalization, VSCode extension, translations, developer tools"
-  />
-);
+export const Head = (props: PageProps<PageProps, PageContext>) => {
+  return (
+    <SEO
+      title="Developer's i18n Companion"
+      description="Install and configure the i18nWeave extension for Visual Studio Code. Instructions for Windows, Linux, and macOS."
+      keywords="i18next, i18n, react, next.js, angular, i18n-next, deepl, internationalization, VSCode extension, Windows, Linux, macOS"
+      pageContext={props.pageContext}
+      pathname={props.location.pathname}
+    />
+  );
+};
 
 export const query = graphql`
   query ($language: String!) {

--- a/src/pages/getting-started.tsx
+++ b/src/pages/getting-started.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import { Layout } from '@i18n-weave/ui/ui-layout';
-import { SEO } from '@i18n-weave/ui/ui-seo';
 import { SecureLink } from '@i18n-weave/ui/ui-secure-link';
+import { type PageContext, SEO } from '@i18n-weave/ui/ui-seo';
 
 import { type PageProps, graphql } from 'gatsby';
 import { useTranslation } from 'react-i18next';
@@ -53,13 +53,19 @@ const GettingStartedPage: React.FC<PageProps> = () => {
 
 export default GettingStartedPage;
 
-export const Head = (props: PageProps) => (
-  <SEO
-    title="Developer&apos;s i18n Companion"
-    description="i18nWeave helps developers efficiently handle i18next translations in their projects. Increase productivity and ensure consistency across multiple languages."
-    keywords="i18next, i18n, react, next.js, angular, i18n-next, deepl, internationalization, VSCode extension, translations, developer tools"
-  />
-);
+export const Head = (props: PageProps<PageProps, PageContext>) => {
+  const { t } = useTranslation();
+
+  return (
+    <SEO
+      title="Developer's i18n Companion"
+      description="i18nWeave helps developers efficiently handle i18next translations in their projects. Increase productivity and ensure consistency across multiple languages."
+      keywords="i18next, i18n, react, next.js, angular, i18n-next, deepl, internationalization, VSCode extension, translations, developer tools"
+      pageContext={props.pageContext}
+      pathname={props.location.pathname}
+    />
+  );
+};
 
 export const query = graphql`
   query ($language: String!) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import { Layout } from '@i18n-weave/ui/ui-layout';
-import { SEO } from '@i18n-weave/ui/ui-seo';
 import { SecureLink } from '@i18n-weave/ui/ui-secure-link';
+import { type PageContext, SEO } from '@i18n-weave/ui/ui-seo';
 
 import { faAngular, faReact } from '@fortawesome/free-brands-svg-icons';
 import {
@@ -127,13 +127,17 @@ const IndexPage: React.FC<PageProps> = () => {
 
 export default IndexPage;
 
-export const Head = (props: PageProps) => (
-  <SEO
-    title="Developer&apos;s i18n Companion"
-    description="i18nWeave helps developers efficiently handle i18next translations in their projects. Increase productivity and ensure consistency across multiple languages."
-    keywords="i18next, i18n, react, next.js, angular, i18n-next, deepl, internationalization, VSCode extension, translations, developer tools"
-  />
-);
+export const Head = (props: PageProps<PageProps, PageContext>) => {
+  return (
+    <SEO
+      title="Developer's i18n Companion"
+      description="i18nWeave helps developers efficiently handle i18next translations in their projects. Increase productivity and ensure consistency across multiple languages."
+      keywords="i18next, i18n, react, next.js, angular, i18n-next, deepl, internationalization, VSCode extension, translations, developer tools"
+      pageContext={props.pageContext}
+      pathname={props.location.pathname}
+    />
+  );
+};
 
 export const query = graphql`
   query ($language: String!) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -112,9 +112,7 @@
       "@i18n-weave/ui/ui-language-selector": [
         "libs/ui/ui-language-selector/src"
       ],
-      "@i18n-weave/ui/ui-seo": [
-        "libs/ui/ui-seo/src"
-      ],
+      "@i18n-weave/ui/ui-seo": ["libs/ui/ui-seo/src"],
       "@i18n-weave/ui/ui-layout": ["libs/ui/ui-layout/src"],
       "@i18n-weave/ui/ui-secure-link": ["libs/ui/ui-secure-link/src"]
     }


### PR DESCRIPTION
Refactor SEO components to accept pageContext and pathname in Head functions. Change siteUrl in gatsby-config to use variable for flexibility. Remove redundant canonical URL plugin. Ensure consistent imports and type annotations across pages.