### PR TITLE
chore: remove redundant sitemap output option

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -63,7 +63,6 @@ const config: GatsbyConfig = {
     {
       resolve: 'gatsby-plugin-sitemap',
       options: {
-        output: `/sitemap/`, // Define your sitemap directory output
         createLinkInHead: true, // Adding a link to the sitemap in the <head>
         entryLimit: 45000, // Default entry limit
         excludes: ['/404', '/404.html', '/*/404', '/*/404.html'], // Exclude 404 pages


### PR DESCRIPTION
Remove the unnecessary 'output' option from the gatsby-plugin-sitemap configuration to clean up and streamline the configuration file.