### PR TITLE
fix(seo): correctly format URLs for non-English languages

### DIFF
--- a/src/libs/ui/ui-seo/src/lib/seo.tsx
+++ b/src/libs/ui/ui-seo/src/lib/seo.tsx
@@ -36,7 +36,7 @@ export const SEO: React.FC<SEOProps> = ({
       ? window.location.origin
       : 'https://i18nweave.com';
   const originalPath = pathname.replace(`/${currentLanguage}`, '') || '/';
-  const canonicalUrl = `${origin}${currentLanguage === 'en' ? '' : `/${currentLanguage}`}${originalPath === '/' ? '' : originalPath}`;
+  const canonicalUrl = `${origin}${currentLanguage === 'en' ? '' : `/${currentLanguage}`}${originalPath === '/' ? (currentLanguage === 'en' ? '' : '/') : originalPath}`;
 
   console.log(`${origin}${originalPath === '/' ? '' : originalPath}`);
 
@@ -55,7 +55,7 @@ export const SEO: React.FC<SEOProps> = ({
             <link
               key={lang}
               rel="alternate"
-              href={`${origin}${lang === 'en' ? '' : `/${lang}`}${originalPath === '/' ? '' : originalPath}`}
+              href={`${origin}${lang === 'en' ? '' : `/${lang}`}${originalPath === '/' ? (lang === 'en' ? '' : '/') : originalPath}`}
               hrefLang={lang}
             />
           ))}


### PR DESCRIPTION
Update the SEO component to correctly handle trailing slashes in URLs for non-English languages. Adjust the canonicalUrl and alternate link generation logic to ensure URLs are properly formatted.