### PR TITLE
fix: ensure correct URL formats in Gatsby config

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -110,6 +110,10 @@ const config: GatsbyConfig = {
           const { defaultLanguage, languages, originalPath } = i18n;
           let fullUrl = `${siteUrl}${originalPath || path}`; // Correct URL concatenation
 
+          if (fullUrl === 'https://i18nweave.com/') {
+            fullUrl = 'https://i18nweave.com';
+          }
+
           const links = [
             { lang: defaultLanguage || 'en', url: fullUrl },
             { lang: 'x-default', url: fullUrl },
@@ -123,9 +127,7 @@ const config: GatsbyConfig = {
             }
           });
 
-          if (fullUrl === 'https://i18nweave.com/') {
-            fullUrl = 'https://i18nweave.com';
-          }
+          console.log('fullUrl', fullUrl);
 
           return {
             url: fullUrl,

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -108,7 +108,7 @@ const config: GatsbyConfig = {
 
         serialize: ({ path, i18n }: { path: string; i18n: any }) => {
           const { defaultLanguage, languages, originalPath } = i18n;
-          const fullUrl = `${siteUrl}${originalPath || path}`; // Correct URL concatenation
+          let fullUrl = `${siteUrl}${originalPath || path}`; // Correct URL concatenation
 
           const links = [
             { lang: defaultLanguage || 'en', url: fullUrl },
@@ -118,8 +118,14 @@ const config: GatsbyConfig = {
           languages.forEach((lang: string) => {
             if (lang !== defaultLanguage) {
               links.push({ lang, url: `${siteUrl}/${lang}${originalPath}` });
+
+              console.log('pushing link', `${siteUrl}/${lang}${originalPath}`);
             }
           });
+
+          if (fullUrl === 'https://i18nweave.com/') {
+            fullUrl = 'https://i18nweave.com';
+          }
 
           return {
             url: fullUrl,

--- a/src/libs/ui/ui-seo/src/lib/seo.tsx
+++ b/src/libs/ui/ui-seo/src/lib/seo.tsx
@@ -38,8 +38,6 @@ export const SEO: React.FC<SEOProps> = ({
   const originalPath = pathname.replace(`/${currentLanguage}`, '') || '/';
   const canonicalUrl = `${origin}${currentLanguage === 'en' ? '' : `/${currentLanguage}`}${originalPath === '/' ? (currentLanguage === 'en' ? '' : '/') : originalPath}`;
 
-  console.log(`${origin}${originalPath === '/' ? '' : originalPath}`);
-
   return (
     <html lang={currentLanguage}>
       <head>


### PR DESCRIPTION
Update URL concatenation logic and add console log for tracking pushed links. Adjust base URL for specific case to meet correct format.