### PR TITLE
chore: [skip ci] remove console logs from config file

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -122,12 +122,8 @@ const config: GatsbyConfig = {
           languages.forEach((lang: string) => {
             if (lang !== defaultLanguage) {
               links.push({ lang, url: `${siteUrl}/${lang}${originalPath}` });
-
-              console.log('pushing link', `${siteUrl}/${lang}${originalPath}`);
             }
           });
-
-          console.log('fullUrl', fullUrl);
 
           return {
             url: fullUrl,


### PR DESCRIPTION
Remove unnecessary console logs used for debugging link generation in gatsby-config.ts to clean up code and improve performance.