### PR TITLE
feat: [skip ci] add limitations section for DeepL integration in multiple locales

### DIFF
--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -43,7 +43,8 @@
         "introduction": "Extrahiere sofort Übersetzungsschlüssel aus deinen Codedateien, wenn du sie speicherst. i18nWeave nutzt eine intelligente Erkennung von Codeänderungen, um sicherzustellen, dass nur bei Bedarf gescannt wird."
       },
       "automaticTranslation": {
-        "introduction": "Übersetze automatisch fehlende Schlüssel in allen definierten Sprachen, wenn du einer Ressourcendatei eine Übersetzung hinzufügst. i18nWeave unterstützt derzeit die Übersetzung mit DeepL (in der Beta-Phase) und plant, Google Translate bald hinzuzufügen."
+        "introduction": "Übersetze automatisch fehlende Schlüssel in allen definierten Sprachen, wenn du einer Ressourcendatei eine Übersetzung hinzufügst. i18nWeave unterstützt derzeit die Übersetzung mit DeepL (in der Beta-Phase) und plant, Google Translate bald hinzuzufügen.",
+        "limitations": "<0>Einschränkungen:</0> Die DeepL Integration in i18nWeave unterstützt die hier aufgeführten Sprachen: <1>DeepL Dokumentation</1>."
       },
       "easyConfig": {
         "title": "Einfach konfigurieren"

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -43,7 +43,8 @@
         "introduction": "Instantly extract translation keys from your code files whenever you save. i18nWeave uses smart detection of code changes, ensuring scans only happen when necessary."
       },
       "automaticTranslation": {
-        "introduction": "Automatically translate missing keys in all defined languages whenever you add a translation to a resource file. i18nWeave currently supports translation with DeepL (in beta), with plans to add Google Translate soon."
+        "introduction": "Automatically translate missing keys in all defined languages whenever you add a translation to a resource file. i18nWeave currently supports translation with DeepL (in beta), with plans to add Google Translate soon.",
+        "limitations": "<0>Limitations:</0> The DeepL integration in i18nWeave supports the languages listed here: <1>DeepL Documentation</1>."
       },
       "easyConfig": {
         "title": "Easy Config"

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -43,7 +43,8 @@
         "introduction": "Extrae instantáneamente las claves de traducción de tus archivos de código cada vez que los guardes. i18nWeave utiliza la detección inteligente de cambios en el código, garantizando que los análisis sólo se realicen cuando sea necesario."
       },
       "automaticTranslation": {
-        "introduction": "Traduce automáticamente las claves que falten en todos los idiomas definidos cada vez que añadas una traducción a un archivo de recursos. i18nWeave admite actualmente la traducción con DeepL (en versión beta), y tiene previsto añadir Google Translate en breve."
+        "introduction": "Traduce automáticamente las claves que falten en todos los idiomas definidos cada vez que añadas una traducción a un archivo de recursos. i18nWeave admite actualmente la traducción con DeepL (en versión beta), y tiene previsto añadir Google Translate en breve.",
+        "limitations": "<0>Limitaciones:</0> La integración de DeepL en i18nWeave admite los idiomas que se indican aquí: <1>DeepL Documentación</1>."
       },
       "easyConfig": {
         "title": "Configuración sencilla"

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -43,7 +43,8 @@
         "introduction": "Extrait instantanément les clés de traduction de tes fichiers de code à chaque fois que tu les enregistres. i18nWeave utilise une détection intelligente des changements de code, ce qui garantit que les analyses n'ont lieu que lorsque c'est nécessaire."
       },
       "automaticTranslation": {
-        "introduction": "Traduit automatiquement les clés manquantes dans toutes les langues définies chaque fois que tu ajoutes une traduction à un fichier de ressources. i18nWeave prend actuellement en charge la traduction avec DeepL (en version bêta), et prévoit d'ajouter Google Translate prochainement."
+        "introduction": "Traduit automatiquement les clés manquantes dans toutes les langues définies chaque fois que tu ajoutes une traduction à un fichier de ressources. i18nWeave prend actuellement en charge la traduction avec DeepL (en version bêta), et prévoit d'ajouter Google Translate prochainement.",
+        "limitations": "<0>Limitations:</0> L'intégration de DeepL dans i18nWeave prend en charge les langues énumérées ici : <1>DeepL Documentation</1>."
       },
       "easyConfig": {
         "title": "Configuration facile"

--- a/src/locales/nl/common.json
+++ b/src/locales/nl/common.json
@@ -43,7 +43,8 @@
         "introduction": "Haal onmiddellijk vertaalsleutels uit je codebestanden wanneer je ze opslaat. i18nWeave gebruikt slimme detectie van codewijzigingen, zodat scans alleen plaatsvinden wanneer dat nodig is."
       },
       "automaticTranslation": {
-        "introduction": "Automatisch vertalen van ontbrekende toetsen in alle gedefinieerde talen wanneer je een vertaling toevoegt aan een resourcebestand. i18nWeave ondersteunt momenteel vertaling met DeepL (in bèta), met plannen om Google Translate binnenkort toe te voegen."
+        "introduction": "Automatisch vertalen van ontbrekende toetsen in alle gedefinieerde talen wanneer je een vertaling toevoegt aan een resourcebestand. i18nWeave ondersteunt momenteel vertaling met DeepL (in bèta), met plannen om Google Translate binnenkort toe te voegen.",
+        "limitations": "<0>Beperkingen:</0> De DeepL integratie in i18nWeave ondersteunt de hier genoemde talen: <1>DeepL Documentatie</1>."
       },
       "easyConfig": {
         "title": "Eenvoudige configuratie"


### PR DESCRIPTION
Introduce limitations section for DeepL integration in en, de, nl, es, and fr locale files. Enhance user clarity on supported languages by referencing DeepL documentation.