### PR TITLE
feat: enhance footer spacing & add Trans for i18n

### DIFF
--- a/src/libs/ui/ui-layout/src/lib/layout.tsx
+++ b/src/libs/ui/ui-layout/src/lib/layout.tsx
@@ -256,7 +256,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }: LayoutProps) => {
       </div>
 
       {children}
-      <footer className="sticky bottom-0 bg-primary py-4 w-full text-white flex items-center justify-between px-4">
+      <footer className="sticky bottom-0 bg-primary py-2 md:py-4 w-full text-white flex items-center justify-between px-4">
         <div className="flex flex-row items-center space-x-4">
           <SecureLink to="/">
             <StaticImage
@@ -299,12 +299,12 @@ export const Layout: React.FC<LayoutProps> = ({ children }: LayoutProps) => {
         <div className="flex flex-col md:flex-row items-center md:space-x-4">
           <SecureLink
             to="/privacy-policy"
-            className="text-white hover:text-highlight">
+            className="text-white hover:text-highlight py-1">
             Privacy Policy
           </SecureLink>
           <SecureLink
             to="/cookie-policy"
-            className="text-white hover:text-highlight">
+            className="text-white hover:text-highlight py-1">
             Cookie Policy
           </SecureLink>
         </div>

--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -7,7 +7,9 @@ import { LocaleLookUpInfo, type PageContext, SEO } from '@i18n-weave/ui/ui-seo';
 import { i18nKey } from '@i18n-weave/util/util-i18n-key';
 
 import { type PageProps, graphql } from 'gatsby';
-import { useTranslation } from 'gatsby-plugin-react-i18next';
+import { Trans, useTranslation } from 'gatsby-plugin-react-i18next';
+
+i18nKey('section.features.automaticTranslation.limitations');
 
 const FeaturesPage: React.FC<PageProps> = () => {
   const { t } = useTranslation();
@@ -32,14 +34,14 @@ const FeaturesPage: React.FC<PageProps> = () => {
             </span>
           </p>
           <p className="my-2">
-            <span className="font-bold">Limitations:</span> The DeepL
-            integration in i18nWeave supports the languages listed here:{' '}
-            <SecureLink
-              className="text-white underline hover:text-highlight hover:border-highlight"
-              to="https://developers.deepl.com/docs/resources/supported-languages">
-              DeepL Docs
-            </SecureLink>
-            .
+            <Trans i18nKey="section.features.automaticTranslation.limitations">
+              <span className="font-bold"></span>
+              <SecureLink
+                className="text-white underline hover:text-highlight hover:border-highlight"
+                to="https://developers.deepl.com/docs/resources/supported-languages">
+                DeepL Documentation
+              </SecureLink>
+            </Trans>
           </p>
 
           <p className="my-4">{t('section.features.tableView.introduction')}</p>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -91,7 +91,7 @@ const IndexPage: React.FC<PageProps> = () => {
       </section>
       <section
         id="getting-started"
-        className="h-screen flex flex-col items-center bg-variant-2 snap-start scroll-mt-16 pt-8 [@media_(max-height:666px)]:h-fit [@media_(max-height:666px)]:py-8">
+        className="h-section-h flex flex-col items-center bg-variant-2 snap-start scroll-mt-16 pt-8 [@media_(max-height:666px)]:h-fit [@media_(max-height:666px)]:py-8">
         <h3 className="text-primary text-4xl mb-8 text-center max-w-screen-xl">
           {t('section.gettingStarted.title')}
         </h3>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,6 +19,9 @@ module.exports = {
         'variant-2': '#7c9f48',
         'variant-3': '#e0564c',
         'variant-4': '#f2b34c',
+      },
+      height: {
+        'section-h': 'calc(100vh - 9rem)',
       }
     },
   },


### PR DESCRIPTION
Add custom height 'section-h' in tailwind.config.js to improve section sizing. Adjust footer padding in layout.tsx for better responsiveness. Implement Trans component in features.tsx to support dynamic i18n key rendering. Update index.tsx to use 'section-h' class for consistent height calculation across different sections.