### PR TITLE
refactor: comment out siteMetadata in gatsby-config

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -4,10 +4,6 @@ const siteUrl = process.env.URL || `https://i18nweave.com`;
 
 /** @type {*} */
 const config: GatsbyConfig = {
-  siteMetadata: {
-    title: `i18nWeave - Developer's i18n Companion`,
-    siteUrl: siteUrl,
-  },
   // More easily incorporate content into your pages through automatic TypeScript type generation and better GraphQL IntelliSense.
   // If you use VSCode you can also use the GraphQL plugin
   // Learn more at: https://gatsby.dev/graphql-typegen

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -7,6 +7,9 @@ const config: GatsbyConfig = {
   // More easily incorporate content into your pages through automatic TypeScript type generation and better GraphQL IntelliSense.
   // If you use VSCode you can also use the GraphQL plugin
   // Learn more at: https://gatsby.dev/graphql-typegen
+  siteMetadata: {
+    siteUrl: siteUrl,
+  },
   graphqlTypegen: true,
   plugins: [
     {


### PR DESCRIPTION
Comment out siteMetadata to temporarily disable it while making configuration changes. This will help avoid potential conflicts and errors during development.